### PR TITLE
Update tests

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,21 +1,4 @@
-import path from 'path'
-import { fs, vol } from 'memfs'
-
-const packagesRoot = path.resolve(process.cwd(), 'packages')
-
-vol.fromJSON(
-    {
-        'package1/package.json': JSON.stringify({
-            "description": "A collection of common visual components.",
-            "felibPackageGroup": "components",
-            "name": "@thm/fe-common-components",
-            "version": "0.1.0",
-          }),
-        'package2/package.json': '{}',
-        'package3/package.json': '{}',
-    },
-    packagesRoot
-)
+import { fs } from 'memfs'
 
 // This needs to be module.exports, not export default, in order to mock fs properly
 module.exports = fs

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,4 +1,21 @@
-import { fs } from 'memfs'
+import path from 'path'
+import { fs, vol } from 'memfs'
+
+const packagesRoot = path.resolve(process.cwd(), 'packages')
+
+vol.fromJSON(
+    {
+        'package1/package.json': JSON.stringify({
+            "description": "A collection of common visual components.",
+            "felibPackageGroup": "components",
+            "name": "@thm/fe-common-components",
+            "version": "0.1.0",
+          }),
+        'package2/package.json': '{}',
+        'package3/package.json': '{}',
+    },
+    packagesRoot
+)
 
 // This needs to be module.exports, not export default, in order to mock fs properly
 module.exports = fs

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,20 +1,4 @@
-import { fs, vol } from 'memfs'
-import path from 'path'
-
-const packagesRoot = path.resolve(process.cwd(), 'packages')
-vol.fromJSON(
-    {
-        'package1/package.json': JSON.stringify({
-            "description": "A collection of common visual components.",
-            "felibPackageGroup": "components",
-            "name": "@thm/fe-common-components",
-            "version": "0.1.0",
-          }),
-        'package2/package.json': '{}',
-        'package3/package.json': '{}',
-    },
-    packagesRoot
-)
+import { fs } from 'memfs'
 
 // This needs to be module.exports, not export default, in order to mock fs properly
 module.exports = fs

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "jest": {
         "collectCoverageFrom": [
             "src/**/*.js"
+        ],
+        "setupFilesAfterEnv": [
+            "<rootDir>/test/setup.js"
         ]
     }
 }

--- a/src/__mocks__/command-helpers.js
+++ b/src/__mocks__/command-helpers.js
@@ -4,21 +4,24 @@ import getPackageInfo from '../get-package-info'
 const helpers = jest.genMockFromModule('../command-helpers')
 
 let lernaUpdatedSucceeds = true
-helpers.getLernaUpdatedJson = () =>
+
+const getLernaUpdatedJson = () =>
     lernaUpdatedSucceeds
         ? getPackageInfo({ useRegistry: true }).then(
             list => JSON.stringify(list),
         )
         : Promise.reject(new Error())
-helpers.__setLernaUpdatedSucceeds = value => {
+
+const __setLernaUpdatedSucceeds = value => {
     lernaUpdatedSucceeds = value
 }
 
-helpers.getNpmVersionFromRegistry = packageName =>
+const getNpmVersionFromRegistry = packageName =>
     Promise.resolve(mockRegistry.view(packageName) || '0.1.0')
 
 let lernaPublishSucceeds = true
-helpers.lernaPublish = jest.fn(
+
+const lernaPublish = jest.fn(
     () =>
         lernaPublishSucceeds
             ? helpers.getLernaUpdatedJson().then(lernaUpdatedJson =>
@@ -32,17 +35,30 @@ helpers.lernaPublish = jest.fn(
               )
             : Promise.reject(new Error()),
 )
-helpers.__setLernaPublishSucceeds = value => {
+
+const __setLernaPublishSucceeds = value => {
     lernaPublishSucceeds = value
 }
 
 let createGitTagSucceeds = true
-helpers.createGitTag = jest.fn(
+
+const createGitTag = jest.fn(
     () =>
         createGitTagSucceeds ? Promise.resolve() : Promise.reject(new Error()),
 )
-helpers.__setCreateGitTagSucceeds = value => {
+
+const __setCreateGitTagSucceeds = value => {
     createGitTagSucceeds = value
 }
 
-module.exports = helpers
+const mocks = {
+    getLernaUpdatedJson,
+    __setLernaUpdatedSucceeds,
+    getNpmVersionFromRegistry,
+    lernaPublish,
+    __setLernaPublishSucceeds,
+    createGitTag,
+    __setCreateGitTagSucceeds,
+}
+
+module.exports = Object.assign(helpers, mocks)

--- a/src/__mocks__/command-helpers.js
+++ b/src/__mocks__/command-helpers.js
@@ -1,16 +1,15 @@
 import mockRegistry from '../../test/mock-registry'
+import getPackageInfo from '../get-package-info'
 
 const helpers = jest.genMockFromModule('../command-helpers')
 
-let lernaUpdatedJson = JSON.stringify([])
 let lernaUpdatedSucceeds = true
 helpers.getLernaUpdatedJson = () =>
     lernaUpdatedSucceeds
-        ? Promise.resolve(lernaUpdatedJson)
+        ? getPackageInfo({ useRegistry: true }).then(
+            list => JSON.stringify(list),
+        )
         : Promise.reject(new Error())
-helpers.__setLernaUpdatedJson = obj => {
-    lernaUpdatedJson = JSON.stringify(obj)
-}
 helpers.__setLernaUpdatedSucceeds = value => {
     lernaUpdatedSucceeds = value
 }
@@ -22,11 +21,11 @@ let lernaPublishSucceeds = true
 helpers.lernaPublish = jest.fn(
     () =>
         lernaPublishSucceeds
-            ? Promise.resolve(
+            ? helpers.getLernaUpdatedJson().then(lernaUpdatedJson =>
                   JSON.parse(lernaUpdatedJson).reduce(
                       (map, { name, version }) => ({
                           ...map,
-                          [name]: `${version}1`,
+                          [name]: version,
                       }),
                       {},
                   ),

--- a/src/__mocks__/command-helpers.js
+++ b/src/__mocks__/command-helpers.js
@@ -1,4 +1,5 @@
 const helpers = jest.genMockFromModule('../command-helpers')
+import mockRegistry from '../../test/mock-registry'
 
 let lernaUpdatedJson = JSON.stringify([])
 let lernaUpdatedSucceeds = true
@@ -15,10 +16,7 @@ helpers.__setLernaUpdatedSucceeds = value => {
 
 const npmRegistryVersions = {}
 helpers.getNpmVersionFromRegistry = packageName =>
-    Promise.resolve(npmRegistryVersions[packageName] || '0.1.0')
-helpers.__setNpmRegistryVersion = (packageName, version) => {
-    npmRegistryVersions[packageName] = version
-}
+    Promise.resolve(mockRegistry.view(packageName) || '0.1.0')
 
 let lernaPublishSucceeds = true
 helpers.lernaPublish = jest.fn(

--- a/src/__mocks__/command-helpers.js
+++ b/src/__mocks__/command-helpers.js
@@ -1,5 +1,6 @@
-const helpers = jest.genMockFromModule('../command-helpers')
 import mockRegistry from '../../test/mock-registry'
+
+const helpers = jest.genMockFromModule('../command-helpers')
 
 let lernaUpdatedJson = JSON.stringify([])
 let lernaUpdatedSucceeds = true
@@ -14,7 +15,6 @@ helpers.__setLernaUpdatedSucceeds = value => {
     lernaUpdatedSucceeds = value
 }
 
-const npmRegistryVersions = {}
 helpers.getNpmVersionFromRegistry = packageName =>
     Promise.resolve(mockRegistry.view(packageName) || '0.1.0')
 

--- a/src/update-package-versions.js
+++ b/src/update-package-versions.js
@@ -10,9 +10,7 @@ const updatePackageJsonVersions = (changedPackages, { registryUrl } = {}) =>
             ([packageName, currentRegistryVersion]) => {
                 const modifiedPackageName = packageName.split('@thm/').pop()
                 const packageJsonFilePath = path.join(
-                    __dirname,
-                    '..',
-                    '..',
+                    process.cwd(),
                     root,
                     modifiedPackageName,
                     'package.json',

--- a/test/__snapshots__/deployPackages.test.js.snap
+++ b/test/__snapshots__/deployPackages.test.js.snap
@@ -1,10 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`deployPackages function when it succeeds logs a list of packages 1`] = `
-Object {
-  "description": "A collection of common visual components.",
-  "group": "components",
-  "name": "@thm/fe-common-components",
-  "version": "0.1.0",
-}
+Array [
+  Object {
+    "description": "A sample package package1",
+    "group": "components",
+    "name": "package1",
+    "version": "1.0.0",
+  },
+  Object {
+    "description": "A sample package package2",
+    "group": "components",
+    "name": "package2",
+    "version": "0.3.0",
+  },
+  Object {
+    "description": "A sample package package3",
+    "group": "components",
+    "name": "package3",
+    "version": "2.3.1",
+  },
+]
 `;

--- a/test/deployPackages.test.js
+++ b/test/deployPackages.test.js
@@ -7,26 +7,20 @@ import {
     __setLernaPublishSucceeds,
     __setCreateGitTagSucceeds,
 } from '../src/command-helpers'
-
-const mockPackageList = [
-    {
-        name: 'package1',
-    },
-    {
-        name: 'package2',
-    },
-]
+import getPackageInfo from '../src/get-package-info'
 
 describe('deployPackages function', () => {
     const stdout = jest.fn()
     const stderr = jest.fn()
     const deployPackages = () => _deployPackages({ stderr, stdout })
+    let mockPackageList
 
-    beforeEach(() => {
+    beforeEach(async () => {
         stdout.mockClear()
         stderr.mockClear()
         lernaPublish.mockClear()
         createGitTag.mockClear()
+        mockPackageList = await getPackageInfo()
     })
 
     describe('when it succeeds', () => {

--- a/test/deployPackages.test.js
+++ b/test/deployPackages.test.js
@@ -10,14 +10,12 @@ import {
     __setCreateGitTagSucceeds,
 } from '../src/command-helpers'
 
-jest.mock('../src/update-package-versions', () => jest.fn())
-
 const mockPackageList = [
     {
-        name: 'package-1',
+        name: 'package1',
     },
     {
-        name: 'package-2',
+        name: 'package2',
     },
 ]
 

--- a/test/deployPackages.test.js
+++ b/test/deployPackages.test.js
@@ -10,8 +10,6 @@ import {
     __setCreateGitTagSucceeds,
 } from '../src/command-helpers'
 
-jest.mock('fs')
-jest.mock('../src/command-helpers')
 jest.mock('../src/update-package-versions', () => jest.fn())
 
 const mockPackageList = [
@@ -26,7 +24,7 @@ const mockPackageList = [
 describe('deployPackages function', () => {
     const stdout = jest.fn()
     const stderr = jest.fn()
-    const deployPackages = () => _deployPackages({ stderr, stdout, fs, vol})
+    const deployPackages = () => _deployPackages({ stderr, stdout })
 
     beforeEach(() => {
         stdout.mockClear()
@@ -63,7 +61,7 @@ describe('deployPackages function', () => {
             })
         })
 
-        it('does not do the publish if there no packages to publish', () => {
+        it('does not do the publish if there are no packages to publish', () => {
             __setLernaUpdatedSucceeds(true)
             __setLernaPublishSucceeds(true)
             __setLernaUpdatedJson([])

--- a/test/deployPackages.test.js
+++ b/test/deployPackages.test.js
@@ -1,5 +1,3 @@
-const { fs, vol } = require('memfs')
-
 import { deployPackages as _deployPackages } from '..'
 import {
     __setLernaUpdatedSucceeds,
@@ -41,9 +39,7 @@ describe('deployPackages function', () => {
                 .resolves.toBeUndefined()
                 .then(() => {
                     expect(
-                        JSON.parse(stdout.mock.calls[0][0]).find(
-                            ({ name }) => name === '@thm/fe-common-components',
-                        ),
+                        JSON.parse(stdout.mock.calls[0][0]),
                     ).toMatchSnapshot()
                 }))
 

--- a/test/fetch-updated-package-versions.test.js
+++ b/test/fetch-updated-package-versions.test.js
@@ -3,22 +3,18 @@ import {
     __setLernaUpdatedJson,
 } from '../src/command-helpers'
 import mockRegistry from './mock-registry'
+import getPackageInfo from '../src/get-package-info'
 
 describe('fetchUpdatedPackageVersions function', () => {
     it('fetches the updated package versions', async () => {
-        const mockPackageMap = {
-            'package-1': '0.2.0',
-            'package-2': '0.3.0',
-        }
-        Object.entries(mockPackageMap).forEach(([packageName, version]) => {
-            mockRegistry.publish(packageName, version)
-        })
-        __setLernaUpdatedJson(
-            Object.keys(mockPackageMap).map(packageName => ({
-                name: packageName,
-            })),
-        )
+        const packageInfo = await getPackageInfo({ useRegistry: true })
+
+        __setLernaUpdatedJson(packageInfo)
+
         const versions = await fetchUpdatedPackageVersions()
-        expect(versions).toMatchObject(mockPackageMap)
+
+        Object.entries(versions).forEach(([packageName, version]) => {
+            expect(mockRegistry.view(packageName)).toBe(version)
+        })
     })
 })

--- a/test/fetch-updated-package-versions.test.js
+++ b/test/fetch-updated-package-versions.test.js
@@ -1,8 +1,8 @@
 import fetchUpdatedPackageVersions from '../src/fetch-updated-package-versions'
 import {
-    __setNpmRegistryVersion,
     __setLernaUpdatedJson,
 } from '../src/command-helpers'
+import mockRegistry from './mock-registry'
 
 describe('fetchUpdatedPackageVersions function', () => {
     it('fetches the updated package versions', async () => {
@@ -11,7 +11,7 @@ describe('fetchUpdatedPackageVersions function', () => {
             'package-2': '0.3.0',
         }
         Object.entries(mockPackageMap).forEach(([packageName, version]) => {
-            __setNpmRegistryVersion(packageName, version)
+            mockRegistry.publish(packageName, version)
         })
         __setLernaUpdatedJson(
             Object.keys(mockPackageMap).map(packageName => ({

--- a/test/fetch-updated-package-versions.test.js
+++ b/test/fetch-updated-package-versions.test.js
@@ -7,10 +7,6 @@ import getPackageInfo from '../src/get-package-info'
 
 describe('fetchUpdatedPackageVersions function', () => {
     it('fetches the updated package versions', async () => {
-        const packageInfo = await getPackageInfo({ useRegistry: true })
-
-        __setLernaUpdatedJson(packageInfo)
-
         const versions = await fetchUpdatedPackageVersions()
 
         Object.entries(versions).forEach(([packageName, version]) => {

--- a/test/fetch-updated-package-versions.test.js
+++ b/test/fetch-updated-package-versions.test.js
@@ -4,8 +4,6 @@ import {
     __setLernaUpdatedJson,
 } from '../src/command-helpers'
 
-jest.mock('../src/command-helpers')
-
 describe('fetchUpdatedPackageVersions function', () => {
     it('fetches the updated package versions', async () => {
         const mockPackageMap = {

--- a/test/mock-registry.js
+++ b/test/mock-registry.js
@@ -1,0 +1,17 @@
+let registry = {}
+
+const publish = (name, version) => {
+    registry[name] = version
+}
+
+const view = name => registry[name]
+
+const reset = () => {
+    registry = {}
+}
+
+export default {
+    publish,
+    view,
+    reset
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,20 @@
+import path from 'path'
+import { vol } from 'memfs'
+
+const packagesRoot = path.resolve(process.cwd(), 'packages')
+vol.fromJSON(
+    {
+        'package1/package.json': JSON.stringify({
+            "description": "A collection of common visual components.",
+            "felibPackageGroup": "components",
+            "name": "@thm/fe-common-components",
+            "version": "0.1.0",
+          }),
+        'package2/package.json': '{}',
+        'package3/package.json': '{}',
+    },
+    packagesRoot
+)
+
+jest.mock('fs')
+jest.mock('../src/command-helpers')

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,2 +1,39 @@
+import path from 'path'
+import { vol } from 'memfs'
+import mockRegistry from './mock-registry'
+
 jest.mock('fs')
 jest.mock('../src/command-helpers')
+
+const packagesRoot = path.resolve(process.cwd(), 'packages')
+
+const mockPackages = {
+    'package1': '1.0.0',
+    'package2': '0.3.0',
+    'package3': '2.3.1'
+}
+
+beforeEach(() => {
+    vol.fromJSON(
+        Object.entries(mockPackages).reduce(
+            (files, [packageName, version]) =>
+            Object.assign(
+                files,
+                {
+                    [`${packageName}/package.json`]: JSON.stringify({
+                        description: `A sample package ${packageName}`,
+                        felibPackageGroup: 'components',
+                        name: packageName,
+                        version: version,
+                    })
+                }
+            ),
+            {}
+        ),
+        packagesRoot
+    )
+    mockRegistry.reset()
+    Object.entries(mockPackages).forEach(([packageName, version]) => {
+        mockRegistry.publish(packageName, version)
+    })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,20 +1,2 @@
-import path from 'path'
-import { vol } from 'memfs'
-
-const packagesRoot = path.resolve(process.cwd(), 'packages')
-vol.fromJSON(
-    {
-        'package1/package.json': JSON.stringify({
-            "description": "A collection of common visual components.",
-            "felibPackageGroup": "components",
-            "name": "@thm/fe-common-components",
-            "version": "0.1.0",
-          }),
-        'package2/package.json': '{}',
-        'package3/package.json': '{}',
-    },
-    packagesRoot
-)
-
 jest.mock('fs')
 jest.mock('../src/command-helpers')


### PR DESCRIPTION
The general idea is to centralize on a "global" mock registry and a "global" mock filesystem with a several packages already hard-coded in memory. Then we still never have to hit the network or filesystem, and it's a bit easier to keep track of what the packages look like.