### PR TITLE
test: Add more tests for updating of package.json files

### DIFF
--- a/src/update-package-versions.js
+++ b/src/update-package-versions.js
@@ -35,8 +35,7 @@ const updatePackageJsonVersions = (changedPackages, { registryUrl } = {}) =>
                 ).then(dependencies => {
                     const dependencyMap = dependencies.reduce(
                         (map, [name, version]) => {
-                            map[name] = version // eslint-disable-line no-param-reassign
-
+                            map[name] = version
                             return map
                         },
                         {},

--- a/test/__snapshots__/deployPackages.test.js.snap
+++ b/test/__snapshots__/deployPackages.test.js.snap
@@ -1,23 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`deployPackages function updates the package.json files of the sibling packages 1`] = `
+"{
+    \\"description\\": \\"A sample package @thm/package1\\",
+    \\"felibPackageGroup\\": \\"components\\",
+    \\"name\\": \\"@thm/package1\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"dependencies\\": {
+        \\"@thm/package2\\": \\"^0.3.0\\",
+        \\"@thm/package3\\": \\"^2.3.1\\",
+        \\"lodash\\": \\"*\\"
+    },
+    \\"publishConfig\\": {}
+}"
+`;
+
+exports[`deployPackages function updates the package.json files of the sibling packages 2`] = `
+"{
+    \\"description\\": \\"A sample package @thm/package2\\",
+    \\"felibPackageGroup\\": \\"components\\",
+    \\"name\\": \\"@thm/package2\\",
+    \\"version\\": \\"0.3.0\\",
+    \\"dependencies\\": {
+        \\"@thm/package3\\": \\"^2.3.1\\"
+    },
+    \\"publishConfig\\": {}
+}"
+`;
+
+exports[`deployPackages function updates the package.json files of the sibling packages 3`] = `
+"{
+    \\"description\\": \\"A sample package @thm/package3\\",
+    \\"felibPackageGroup\\": \\"components\\",
+    \\"name\\": \\"@thm/package3\\",
+    \\"version\\": \\"2.3.1\\",
+    \\"dependencies\\": {
+        \\"dayum\\": \\"*\\"
+    },
+    \\"publishConfig\\": {}
+}"
+`;
+
+exports[`deployPackages function updates the package.json publish config if given 1`] = `
+"{
+    \\"description\\": \\"A sample package @thm/package1\\",
+    \\"felibPackageGroup\\": \\"components\\",
+    \\"name\\": \\"@thm/package1\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"dependencies\\": {
+        \\"@thm/package2\\": \\"^0.3.0\\",
+        \\"@thm/package3\\": \\"^2.3.1\\",
+        \\"lodash\\": \\"*\\"
+    },
+    \\"publishConfig\\": {
+        \\"registry\\": \\"http://example.com/production-registry/\\"
+    }
+}"
+`;
+
+exports[`deployPackages function updates the package.json publish config if given 2`] = `
+"{
+    \\"description\\": \\"A sample package @thm/package2\\",
+    \\"felibPackageGroup\\": \\"components\\",
+    \\"name\\": \\"@thm/package2\\",
+    \\"version\\": \\"0.3.0\\",
+    \\"dependencies\\": {
+        \\"@thm/package3\\": \\"^2.3.1\\"
+    },
+    \\"publishConfig\\": {
+        \\"registry\\": \\"http://example.com/production-registry/\\"
+    }
+}"
+`;
+
+exports[`deployPackages function updates the package.json publish config if given 3`] = `
+"{
+    \\"description\\": \\"A sample package @thm/package3\\",
+    \\"felibPackageGroup\\": \\"components\\",
+    \\"name\\": \\"@thm/package3\\",
+    \\"version\\": \\"2.3.1\\",
+    \\"dependencies\\": {
+        \\"dayum\\": \\"*\\"
+    },
+    \\"publishConfig\\": {
+        \\"registry\\": \\"http://example.com/production-registry/\\"
+    }
+}"
+`;
+
 exports[`deployPackages function when it succeeds logs a list of packages 1`] = `
 Array [
   Object {
-    "description": "A sample package package1",
+    "description": "A sample package @thm/package1",
     "group": "components",
-    "name": "package1",
+    "name": "@thm/package1",
     "version": "1.0.0",
   },
   Object {
-    "description": "A sample package package2",
+    "description": "A sample package @thm/package2",
     "group": "components",
-    "name": "package2",
+    "name": "@thm/package2",
     "version": "0.3.0",
   },
   Object {
-    "description": "A sample package package3",
+    "description": "A sample package @thm/package3",
     "group": "components",
-    "name": "package3",
+    "name": "@thm/package3",
     "version": "2.3.1",
   },
 ]

--- a/test/deployPackages.test.js
+++ b/test/deployPackages.test.js
@@ -62,21 +62,22 @@ describe('deployPackages function', () => {
         })
     })
 
+    const getPackageJsonContents = packageName =>
+        fs.readFileSync(
+            path.join(
+                process.cwd(),
+                'packages',
+                packageName.replace('@thm/', ''),
+                'package.json',
+            ),
+            'utf8',
+        )
+
     it('updates the package.json files of the sibling packages', async () => {
         await deployPackages()
         const packageInfo = await getPackageInfo()
         packageInfo.forEach(({ name }) => {
-            expect(
-                fs.readFileSync(
-                    path.join(
-                        process.cwd(),
-                        'packages',
-                        name.replace('@thm/', ''),
-                        'package.json',
-                    ),
-                    'utf8',
-                ),
-            ).toMatchSnapshot()
+            expect(getPackageJsonContents(name)).toMatchSnapshot()
         })
     })
 
@@ -86,17 +87,7 @@ describe('deployPackages function', () => {
         })
         const packageInfo = await getPackageInfo()
         packageInfo.forEach(({ name }) => {
-            expect(
-                fs.readFileSync(
-                    path.join(
-                        process.cwd(),
-                        'packages',
-                        name.replace('@thm/', ''),
-                        'package.json',
-                    ),
-                    'utf8',
-                ),
-            ).toMatchSnapshot()
+            expect(getPackageJsonContents(name)).toMatchSnapshot()
         })
     })
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -22,34 +22,42 @@ const mockPackages = {
     },
 }
 
-beforeEach(() => {
-    vol.reset()
-    vol.fromJSON(
-        Object.entries(mockPackages).reduce(
-            (files, [packageName, { version, dependencies }]) =>
-                Object.assign(files, {
-                    [`${packageName.replace(
-                        '@thm/',
-                        '',
-                    )}/package.json`]: JSON.stringify({
-                        description: `A sample package ${packageName}`,
-                        felibPackageGroup: 'components',
-                        name: packageName,
-                        version: version,
-                        dependencies: dependencies.reduce(
-                            (dependencyMap, dependency) =>
-                                Object.assign(dependencyMap, {
-                                    [dependency]: '*',
-                                }),
-                            {},
-                        ),
-                        publishConfig: {},
-                    }),
+function buildPackageJson(packageName, version, dependencies) {
+    return {
+        description: `A sample package ${packageName}`,
+        felibPackageGroup: 'components',
+        name: packageName,
+        version: version,
+        dependencies: dependencies.reduce(
+            (dependencyMap, dependency) =>
+                Object.assign(dependencyMap, {
+                    [dependency]: '*',
                 }),
             {},
         ),
-        packagesRoot,
+        publishConfig: {},
+    }
+}
+
+function getPackageJsonPath(packageName) {
+    return `${packageName.replace('@thm/', '')}/package.json`
+}
+
+function getMockPackageJsonFiles(mockPackages) {
+    return Object.entries(mockPackages).reduce(
+        (files, [packageName, { version, dependencies }]) =>
+            Object.assign(files, {
+                [getPackageJsonPath(packageName)]: JSON.stringify(
+                    buildPackageJson(packageName, version, dependencies),
+                ),
+            }),
+        {},
     )
+}
+
+beforeEach(() => {
+    vol.reset()
+    vol.fromJSON(getMockPackageJsonFiles(mockPackages), packagesRoot)
     mockRegistry.reset()
     Object.entries(mockPackages).forEach(([packageName, { version }]) => {
         mockRegistry.publish(packageName, version)

--- a/test/setup.js
+++ b/test/setup.js
@@ -8,26 +8,30 @@ jest.mock('../src/command-helpers')
 const packagesRoot = path.resolve(process.cwd(), 'packages')
 
 const mockPackages = {
-    package1: {
+    '@thm/package1': {
         version: '1.0.0',
-        dependencies: ['package2', 'package3'],
+        dependencies: ['@thm/package2', '@thm/package3', 'lodash'],
     },
-    package2: {
+    '@thm/package2': {
         version: '0.3.0',
-        dependencies: ['package3'],
+        dependencies: ['@thm/package3'],
     },
-    package3: {
+    '@thm/package3': {
         version: '2.3.1',
-        dependencies: [],
+        dependencies: ['dayum'],
     },
 }
 
 beforeEach(() => {
+    vol.reset()
     vol.fromJSON(
         Object.entries(mockPackages).reduce(
             (files, [packageName, { version, dependencies }]) =>
                 Object.assign(files, {
-                    [`${packageName}/package.json`]: JSON.stringify({
+                    [`${packageName.replace(
+                        '@thm/',
+                        '',
+                    )}/package.json`]: JSON.stringify({
                         description: `A sample package ${packageName}`,
                         felibPackageGroup: 'components',
                         name: packageName,
@@ -35,12 +39,11 @@ beforeEach(() => {
                         dependencies: dependencies.reduce(
                             (dependencyMap, dependency) =>
                                 Object.assign(dependencyMap, {
-                                    [`"${dependency}"`]: `^${
-                                        mockPackages[dependency]
-                                    }`,
+                                    [dependency]: '*',
                                 }),
                             {},
                         ),
+                        publishConfig: {},
                     }),
                 }),
             {},


### PR DESCRIPTION
These tests still hard code the `@thm` scope, but we basically want to make sure we preserve functionality as we rip out this Top Hat-specific logic, so the first step is writing tests.