### PR TITLE
chore: Ignore lerna updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,6 +6,10 @@ update_configs:
     version_requirement_updates: "increase_versions"
     commit_message:
       prefix: "chore"
+    ignored_updates:
+      - match:
+          dependency_name: lerna
+          version_requirement: "> 3.15.0"
   - package_manager: "javascript"
     directory: "/website"
     update_schedule: "weekly"


### PR DESCRIPTION
We're depending on specific command outputs, so until we change that it's best to lock the version