### PR TITLE
feat: add prepend changelog support, close #209

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+max_line_length = off
+
+[*.yml]
+indent_size = 2
+
+[{CHANGELOG.md,package.json,yarn.lock}]
+indent_size = false

--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ In your monorepo's root package.json, add:
 },
 ```
 
+#### Changelog
+
+If you choose to use the `--prepend-changelog CHANGELOG.md` flag or related API config property, in your CHANGELOG.md file you'll need to insert a marker to let monodeploy know where to insert the changelog entries. For example:
+
+```md
+# My Example Changelog
+
+Some blurb here.
+
+<!-- MONODEPLOY:BELOW -->
+
+## v1.0.0
+
+Some entry.
+```
+
+The marker `<!-- MONODEPLOY:BELOW -->` must match exactly. It is whitespace and case-sensitive.
+
+
 ## API
 
 Monodeploy supports both a Command Line Interface, as well as a Node API.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,9 @@ interface ArgOutput {
     logLevel?: number
     conventionalChangelogConfig?: string
     changesetFilename?: string
+    changelogFilename?: string
     access?: string
+    push?: boolean
 }
 
 const { argv } = yargs
@@ -54,6 +56,15 @@ const { argv } = yargs
         type: 'string',
         description: 'Changeset output filename',
     })
+    .option('prepend-changelog', {
+        type: 'string',
+        description: 'Changelog file to prepend changelog entries',
+    })
+    .option('push', {
+        type: 'boolean',
+        description: 'Whether to push git changes to remote',
+        default: true,
+    })
     .option('access', {
         type: 'string',
         description:
@@ -79,10 +90,12 @@ const cwd = argv.cwd ?? process.cwd()
             commitSha:
                 argv.gitCommitSha ?? (await gitResolveSha('HEAD', { cwd })),
             remote: argv.gitRemote ?? 'origin',
+            push: argv.push ?? true,
         },
         conventionalChangelogConfig:
             argv.conventionalChangelogConfig ?? undefined,
         changesetFilename: argv.changesetFilename ?? undefined,
+        changelogFilename: argv.changelogFilename ?? undefined,
         access: argv.access ?? 'public',
     }
 

--- a/src/core/prependChangelogFile.ts
+++ b/src/core/prependChangelogFile.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+import logging from '../logging'
+import type {
+    ChangesetSchema,
+    MonodeployConfiguration,
+    YarnContext,
+} from '../types'
+
+const MARKER = '<!-- MONODEPLOY:BELOW -->'
+
+const prependChangelogFile = async (
+    config: MonodeployConfiguration,
+    context: YarnContext,
+    changeset: ChangesetSchema,
+): Promise<void> => {
+    if (!config.changelogFilename) return
+
+    const changelogFilename = path.resolve(config.cwd, config.changelogFilename)
+
+    let changelogContents: string[] = []
+    try {
+        changelogContents = (
+            await fs.readFile(changelogFilename, { encoding: 'utf-8' })
+        ).split('\n')
+    } catch (err) {
+        logging.error(
+            `[Changelog] Unable to read changelog contents at ${changelogFilename}`,
+        )
+        throw err
+    }
+
+    const changelogOffset = changelogContents.findIndex(
+        value => value.trim() === MARKER,
+    )
+    if (changelogOffset === -1) {
+        logging.error(`[Changelog] Missing changelog marker: '${MARKER}'`)
+        throw new Error('Unable to prepend changelog.')
+    }
+
+    const newEntries = Object.entries(changeset)
+        .sort(([pkgNameA], [pkgNameB]) => pkgNameA.localeCompare(pkgNameB))
+        .map(([, changesetValue]) => changesetValue.changelog)
+        .filter(value => value)
+        .join('\n')
+        .trim()
+
+    changelogContents.splice(changelogOffset + 1, 0, `\n${newEntries}\n`)
+
+    const dataToWrite = changelogContents.join('\n')
+
+    if (config.dryRun) {
+        logging.debug(`[Changelog] Skipping changelog update.`)
+    } else {
+        await fs.writeFile(changelogFilename, dataToWrite, {
+            encoding: 'utf-8',
+        })
+    }
+
+    logging.info(`[Changelog] Updated ${changelogFilename}`)
+}
+
+export default prependChangelogFile

--- a/src/core/publishPackages.ts
+++ b/src/core/publishPackages.ts
@@ -62,7 +62,11 @@ const publishPackages = async (
     )
 
     // Push git tags
-    await pushTags(config, context, newVersions)
+    if (config.git.push) {
+        await pushTags(config, context, newVersions)
+    } else {
+        logging.info(`[Publish] Skipping git tag publish.`)
+    }
 }
 
 export default publishPackages

--- a/src/monodeploy.ts
+++ b/src/monodeploy.ts
@@ -8,6 +8,7 @@ import applyReleases from './core/applyReleases'
 import getExplicitVersionStrategies from './core/getExplicitVersionStrategies'
 import getImplicitVersionStrategies from './core/getImplicitVersionStrategies'
 import getLatestPackageTags from './core/getLatestPackageTags'
+import prependChangelogFile from './core/prependChangelogFile'
 import publishPackages from './core/publishPackages'
 import writeChangesetFile from './core/writeChangesetFile'
 import logging from './logging'
@@ -113,6 +114,8 @@ const monodeploy = async (
             newVersions,
             versionStrategies,
         )
+
+        await prependChangelogFile(config, context, result)
     } catch (err) {
         logging.error(`Monodeploy failed`)
         logging.error(err)

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,11 @@ export interface MonodeployConfiguration {
         baseBranch: string
         commitSha: string
         remote: string
+        push: boolean
     }
     conventionalChangelogConfig?: string
     changesetFilename?: string
+    changelogFilename?: string
     access: string
 }
 


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Adds prepend changelog support as well as "--no-push" flag.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #209, prepend changelog support

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

There's a question as to whether the updated changelog should be auto-committed and pushed.