### PR TITLE
feat: support multiple unconnected package publishing

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "7.16.0-pnpify",
+  "version": "7.18.0-pnpify",
   "main": "./lib/api.js",
   "type": "commonjs"
 }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ yarn monodeploy --help
 If you are okay with the defaults, you can go ahead and add a call to monodeploy to your CI's publish stage:
 
 ```sh
-yarn monodeploy
+yarn monodeploy --push
+```
+
+If you omit `--push`, you can manually push the tags on success:
+
+```sh
+yarn monodeploy && git push --tags
 ```
 
 Or to give things a try first, run monodeploy in dry run mode with verbose logging. Dry run mode won't modify the remote registry, or git.
@@ -125,6 +131,7 @@ try {
             baseBranch: 'master',
             commitSha: 'HEAD',
             remote: 'origin',
+            push: true,
         },
         conventionalChangelogConfig: '@tophat/conventional-changelog-config',
         access: 'public',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs'
 
 import monodeploy from './monodeploy'
-import { gitResolveSha } from './utils/git'
 
 interface ArgOutput {
     registryUrl?: string
@@ -78,25 +77,23 @@ if (argv.logLevel !== undefined && argv.logLevel !== null) {
     process.env.MONODEPLOY_LOG_LEVEL = String(argv.logLevel)
 }
 
-const cwd = argv.cwd ?? process.cwd()
-
+// eslint-disable-next-line @typescript-eslint/no-extra-semi
 ;(async () => {
     const config = {
         registryUrl: argv.registryUrl ?? undefined,
-        cwd,
-        dryRun: argv.dryRun ?? false,
+        cwd: argv.cwd ?? undefined,
+        dryRun: argv.dryRun ?? undefined,
         git: {
-            baseBranch: argv.gitBaseBranch ?? 'origin/master',
-            commitSha:
-                argv.gitCommitSha ?? (await gitResolveSha('HEAD', { cwd })),
-            remote: argv.gitRemote ?? 'origin',
-            push: argv.push ?? false,
+            baseBranch: argv.gitBaseBranch ?? undefined,
+            commitSha: argv.gitCommitSha ?? undefined,
+            remote: argv.gitRemote ?? undefined,
+            push: argv.push ?? undefined,
         },
         conventionalChangelogConfig:
             argv.conventionalChangelogConfig ?? undefined,
         changesetFilename: argv.changesetFilename ?? undefined,
         changelogFilename: argv.changelogFilename ?? undefined,
-        access: argv.access ?? 'public',
+        access: argv.access ?? undefined,
     }
 
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ const { argv } = yargs
     .option('push', {
         type: 'boolean',
         description: 'Whether to push git changes to remote',
-        default: true,
+        default: false,
     })
     .option('access', {
         type: 'string',
@@ -90,7 +90,7 @@ const cwd = argv.cwd ?? process.cwd()
             commitSha:
                 argv.gitCommitSha ?? (await gitResolveSha('HEAD', { cwd })),
             remote: argv.gitRemote ?? 'origin',
-            push: argv.push ?? true,
+            push: argv.push ?? false,
         },
         conventionalChangelogConfig:
             argv.conventionalChangelogConfig ?? undefined,

--- a/src/core/getExplicitVersionStrategies.ts
+++ b/src/core/getExplicitVersionStrategies.ts
@@ -72,7 +72,9 @@ const getExplicitVersionStrategies = async (
     config: MonodeployConfiguration,
     context: YarnContext,
 ): Promise<PackageStrategyMap> => {
-    const commitMessages = await getCommitMessages(config)
+    const commitMessages = (await getCommitMessages(config)).map(
+        commit => commit.body,
+    )
     const strategyDeterminer = config.conventionalChangelogConfig
         ? createGetConventionalRecommendedStrategy(config)
         : getDefaultRecommendedStrategy

--- a/src/core/publishPackages.ts
+++ b/src/core/publishPackages.ts
@@ -62,11 +62,7 @@ const publishPackages = async (
     )
 
     // Push git tags
-    if (config.git.push) {
-        await pushTags(config, context, newVersions)
-    } else {
-        logging.info(`[Publish] Skipping git tag publish.`)
-    }
+    await pushTags(config, context, newVersions)
 }
 
 export default publishPackages

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -24,12 +24,6 @@ const loggerOpts = {
     dryRun: false,
 }
 
-const leftPad = (value: string | number, padding: number): string => {
-    const str = String(value)
-    const whitespace = '0'.repeat(Math.max(padding - str.length, 0))
-    return `${whitespace}${str}`
-}
-
 const getCurrentLogLevel = () => {
     try {
         const envLogLevel = process.env.MONODEPLOY_LOG_LEVEL
@@ -46,10 +40,11 @@ const createLogger = (level: LogLevelType): Logger => (
 ): void => {
     if (getCurrentLogLevel() > level) return
     const date = new Date()
-    const timestamp = `[${leftPad(date.getHours(), 2)}:${leftPad(
+    const timestamp = `[${String(date.getHours()).padStart(2, '0')}:${String(
         date.getMinutes(),
-        2,
-    )}:${leftPad(date.getSeconds(), 2)}.${leftPad(date.getMilliseconds(), 3)}]`
+    ).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}.${String(
+        date.getMilliseconds(),
+    ).padStart(3, '0')}]`
     const colour = levelToColour[level]
 
     const line = [chalk.yellow(timestamp)]

--- a/src/monodeploy.test.ts
+++ b/src/monodeploy.test.ts
@@ -49,7 +49,7 @@ describe('Monodeploy (Dry Run)', () => {
         mockNPM._setTag_('pkg-1', '0.0.1')
         mockNPM._setTag_('pkg-2', '0.0.1')
         mockNPM._setTag_('pkg-3', '0.0.1')
-        mockGit._commitFiles_('feat: some new feature!', [
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', [
             './packages/pkg-1/README.md',
         ])
 
@@ -74,6 +74,7 @@ describe('Monodeploy (Dry Run)', () => {
         mockNPM._setTag_('pkg-2', '0.0.1')
         mockNPM._setTag_('pkg-3', '0.0.1')
         mockGit._commitFiles_(
+            'sha1',
             'feat: some new feature!\n\nBREAKING CHANGE: major bump!',
             ['./packages/pkg-2/README.md'],
         )
@@ -100,7 +101,7 @@ describe('Monodeploy (Dry Run)', () => {
     })
 
     it('defaults to 0.0.0 as base version for first publish', async () => {
-        mockGit._commitFiles_('feat: some new feature!', [
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', [
             './packages/pkg-1/README.md',
         ])
 
@@ -158,7 +159,7 @@ describe('Monodeploy', () => {
         mockNPM._setTag_('pkg-1', '0.0.1')
         mockNPM._setTag_('pkg-2', '0.0.1')
         mockNPM._setTag_('pkg-3', '0.0.1')
-        mockGit._commitFiles_('feat: some new feature!', [
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', [
             './packages/pkg-1/README.md',
         ])
 
@@ -181,7 +182,7 @@ describe('Monodeploy', () => {
         mockNPM._setTag_('pkg-1', '0.0.1')
         mockNPM._setTag_('pkg-2', '0.0.1')
         mockNPM._setTag_('pkg-3', '0.0.1')
-        mockGit._commitFiles_('feat: some new feature!', [
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', [
             './packages/pkg-1/README.md',
         ])
 
@@ -202,6 +203,7 @@ describe('Monodeploy', () => {
         mockNPM._setTag_('pkg-2', '0.0.1')
         mockNPM._setTag_('pkg-3', '0.0.1')
         mockGit._commitFiles_(
+            'sha1',
             'feat: some new feature!\n\nBREAKING CHANGE: major bump!',
             ['./packages/pkg-2/README.md'],
         )
@@ -234,7 +236,7 @@ describe('Monodeploy', () => {
         mockNPM._setTag_('pkg-1', '0.0.1')
         mockNPM._setTag_('pkg-2', '0.0.1')
         mockNPM._setTag_('pkg-3', '0.0.1')
-        mockGit._commitFiles_('feat: some new feature!', [
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', [
             './packages/pkg-1/README.md',
         ])
 

--- a/src/monodeploy.test.ts
+++ b/src/monodeploy.test.ts
@@ -232,6 +232,50 @@ describe('Monodeploy', () => {
         ])
     })
 
+    it('publishes changed workspaces with distinct version stategies and commits', async () => {
+        mockNPM._setTag_('pkg-1', '0.0.1')
+        mockNPM._setTag_('pkg-2', '0.0.1')
+        mockNPM._setTag_('pkg-3', '0.0.1')
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', [
+            './packages/pkg-1/README.md',
+        ])
+        mockGit._commitFiles_('sha2', 'fix: a different fix!', [
+            './packages/pkg-2/README.md',
+        ])
+
+        const result = await monodeploy(monodeployConfig)
+
+        // pkg-1 is explicitly updated with minor bump
+        expect(result['pkg-1'].version).toEqual('0.1.0')
+        expect(result['pkg-1'].changelog).toEqual(
+            expect.stringContaining('some new feature'),
+        )
+
+        // pkg-2 is explicitly updated with patch bump
+        expect(result['pkg-2'].version).toEqual('0.0.2')
+        expect(result['pkg-2'].changelog).not.toEqual(
+            expect.stringContaining('some new feature'),
+        )
+        expect(result['pkg-2'].changelog).toEqual(
+            expect.stringContaining('a different fix'),
+        )
+
+        // pkg-3 depends on pkg-2
+        expect(result['pkg-3'].version).toEqual('0.0.2')
+        expect(result['pkg-3'].changelog).not.toEqual(
+            expect.stringContaining('some new feature'),
+        )
+        expect(result['pkg-3'].changelog).not.toEqual(
+            expect.stringContaining('a different fix'),
+        )
+
+        expect(mockGit._getPushedTags_()).toEqual([
+            'pkg-1@0.1.0',
+            'pkg-2@0.0.2',
+            'pkg-3@0.0.2',
+        ])
+    })
+
     it('updates changelog', async () => {
         mockNPM._setTag_('pkg-1', '0.0.1')
         mockNPM._setTag_('pkg-2', '0.0.1')

--- a/src/monodeploy.ts
+++ b/src/monodeploy.ts
@@ -16,17 +16,21 @@ import type {
     ChangesetSchema,
     MonodeployConfiguration,
     PackageStrategyMap,
+    RecursivePartial,
     YarnContext,
 } from './types'
 import { backupPackageJsons, restorePackageJsons } from './utils/backupPackage'
 import getRegistryUrl from './utils/getRegistryUrl'
 import getWorkspacesToPublish from './utils/getWorkspacesToPublish'
+import mergeDefaultConfig from './utils/mergeDefaultConfig'
 
 export { ChangesetSchema, MonodeployConfiguration } from './types'
 
 const monodeploy = async (
-    config: MonodeployConfiguration,
+    baseConfig: RecursivePartial<MonodeployConfiguration>,
 ): Promise<ChangesetSchema> => {
+    const config: MonodeployConfiguration = await mergeDefaultConfig(baseConfig)
+
     logging.setDryRun(config.dryRun)
     logging.debug(
         `Starting monodeploy with config:`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,11 @@ export interface YarnContext {
     workspace: Workspace
 }
 
+export type CommitMessage = {
+    sha: string
+    body: string
+}
+
 export type PackageTagMap = Map<string, string>
 
 export type PackageStrategyType = 'major' | 'minor' | 'patch'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
 import { Configuration, Project, Workspace } from '@yarnpkg/core'
 
+export type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends Record<string, unknown>
+        ? RecursivePartial<T[P]>
+        : T[P]
+}
+
 export interface MonodeployConfiguration {
     cwd: string
     registryUrl?: string

--- a/src/utils/__mocks__/git.ts
+++ b/src/utils/__mocks__/git.ts
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-const registry = {
+import type { CommitMessage } from '../../types'
+
+const registry: {
+    commits: CommitMessage[]
+    filesModified: string[]
+    tags: string[]
+    pushedTags: string[]
+} = {
     commits: [],
     filesModified: [],
     tags: [],
@@ -14,8 +21,12 @@ export const _reset_ = (): void => {
     registry.pushedTags = []
 }
 
-export const _commitFiles_ = (commit: string, files: string[]): void => {
-    registry.commits.push(commit)
+export const _commitFiles_ = (
+    sha: string,
+    commit: string,
+    files: string[],
+): void => {
+    registry.commits.push({ sha, body: commit })
     registry.filesModified.push(...files)
 }
 
@@ -43,7 +54,9 @@ export const gitLog = async (
     to: string,
     { cwd, DELIMITER }: { cwd: string; DELIMITER: string },
 ): Promise<string> => {
-    return registry.commits.join(`${DELIMITER}\n`)
+    return registry.commits
+        .map(commit => `${commit.sha}\n${commit.body}`)
+        .join(`${DELIMITER}\n`)
 }
 
 export const gitTag = async (

--- a/src/utils/__mocks__/git.ts
+++ b/src/utils/__mocks__/git.ts
@@ -4,19 +4,19 @@ import type { CommitMessage } from '../../types'
 
 const registry: {
     commits: CommitMessage[]
-    filesModified: string[]
+    filesModified: Map<string, string[]>
     tags: string[]
     pushedTags: string[]
 } = {
     commits: [],
-    filesModified: [],
+    filesModified: new Map(),
     tags: [],
     pushedTags: [],
 }
 
 export const _reset_ = (): void => {
     registry.commits = []
-    registry.filesModified = []
+    registry.filesModified = new Map()
     registry.tags = []
     registry.pushedTags = []
 }
@@ -27,7 +27,8 @@ export const _commitFiles_ = (
     files: string[],
 ): void => {
     registry.commits.push({ sha, body: commit })
-    registry.filesModified.push(...files)
+    registry.filesModified.set(sha, registry.filesModified.get(sha) ?? [])
+    registry.filesModified.get(sha).push(...files)
 }
 
 export const _getPushedTags_ = (): string[] => {
@@ -41,12 +42,11 @@ export const gitResolveSha = async (
     return `sha:${ref}`
 }
 
-export const gitDiff = async (
-    from: string,
-    to: string,
+export const gitDiffTree = async (
+    ref: string,
     { cwd }: { cwd: string },
 ): Promise<string> => {
-    return registry.filesModified.join('\n')
+    return (registry.filesModified.get(ref) ?? []).join('\n')
 }
 
 export const gitLog = async (

--- a/src/utils/getCommitMessages.ts
+++ b/src/utils/getCommitMessages.ts
@@ -1,4 +1,4 @@
-import type { MonodeployConfiguration } from '../types'
+import type { CommitMessage, MonodeployConfiguration } from '../types'
 
 import { gitLog } from './git'
 
@@ -6,11 +6,18 @@ const DELIMITER = '-----------------monodeploy-----------------'
 
 const getCommitMessages = async (
     config: MonodeployConfiguration,
-): Promise<string[]> => {
+): Promise<CommitMessage[]> => {
     const from = config.git.baseBranch
     const to = config.git.commitSha
     const logOutput = await gitLog(from, to, { cwd: config.cwd, DELIMITER })
-    return [...logOutput.toString().split(`${DELIMITER}\n`)].filter(msg => msg)
+    return logOutput
+        .toString()
+        .split(`${DELIMITER}\n`)
+        .map(logEntry => {
+            const [sha, ...msg] = logEntry.split('\n')
+            return { sha, body: msg.join('\n') }
+        })
+        .filter(msg => msg.body)
 }
 
 export default getCommitMessages

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -34,7 +34,7 @@ export const gitLog = async (
     to: string,
     { cwd, DELIMITER }: { cwd: string; DELIMITER: string },
 ): Promise<string> => {
-    const gitCommand = `git log ${from}...${to} --format=%B%n${DELIMITER}`
+    const gitCommand = `git log ${from}...${to} --format=%H%n%B%n${DELIMITER}`
     logging.debug(`[Exec] ${gitCommand}`)
     return childProcess.execSync(gitCommand, {
         encoding: 'utf8',

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -16,12 +16,11 @@ export const gitResolveSha = async (
         .trim()
 }
 
-export const gitDiff = async (
-    from: string,
-    to: string,
+export const gitDiffTree = async (
+    ref: string,
     { cwd }: { cwd: string },
 ): Promise<string> => {
-    const gitCommand = `git diff ${from}...${to} --name-only`
+    const gitCommand = `git diff-tree --no-commit-id --name-only -r --root ${ref}`
     logging.debug(`[Exec] ${gitCommand}`)
     return childProcess.execSync(gitCommand, {
         encoding: 'utf8',

--- a/src/utils/mergeDefaultConfig.ts
+++ b/src/utils/mergeDefaultConfig.ts
@@ -1,0 +1,30 @@
+import { MonodeployConfiguration, RecursivePartial } from '../types'
+
+import { gitResolveSha } from './git'
+
+const mergeDefaultConfig = async (
+    baseConfig: RecursivePartial<MonodeployConfiguration>,
+): Promise<MonodeployConfiguration> => {
+    const cwd = baseConfig.cwd ?? process.cwd()
+
+    return {
+        registryUrl: baseConfig.registryUrl ?? undefined,
+        cwd,
+        dryRun: baseConfig.dryRun ?? false,
+        git: {
+            baseBranch: baseConfig.git?.baseBranch ?? 'origin/master',
+            commitSha:
+                baseConfig.git?.commitSha ??
+                (await gitResolveSha('HEAD', { cwd })),
+            remote: baseConfig.git?.remote ?? 'origin',
+            push: baseConfig.git?.push ?? false,
+        },
+        conventionalChangelogConfig:
+            baseConfig.conventionalChangelogConfig ?? undefined,
+        changesetFilename: baseConfig.changesetFilename ?? undefined,
+        changelogFilename: baseConfig.changelogFilename ?? undefined,
+        access: baseConfig.access ?? 'public',
+    }
+}
+
+export default mergeDefaultConfig

--- a/src/utils/pushTags.ts
+++ b/src/utils/pushTags.ts
@@ -20,13 +20,19 @@ function pushTags(
             try {
                 if (!config.dryRun) {
                     await gitTag(tag, { cwd: config.cwd })
-                    await gitPush(tag, {
-                        cwd: config.cwd,
-                        remote: config.git.remote,
-                    })
+                    if (config.git.push) {
+                        await gitPush(tag, {
+                            cwd: config.cwd,
+                            remote: config.git.remote,
+                        })
+                    }
                 }
 
-                logging.info(`[Push Tag] ${tag} (remote: ${config.git.remote})`)
+                logging.info(
+                    `[Push Tag]${
+                        config.git.push ? '' : ' [Skipped]'
+                    } ${tag} (remote: ${config.git.remote})`,
+                )
             } catch (e) {
                 logging.error(
                     `[Push Tag] Failed ${tag} (remote: ${config.git.remote})`,

--- a/src/utils/versionStrategy.ts
+++ b/src/utils/versionStrategy.ts
@@ -2,7 +2,11 @@ import { Readable } from 'stream'
 
 import conventionalCommitsParser, { Commit } from 'conventional-commits-parser'
 
-import type { MonodeployConfiguration, StrategyDeterminer } from '../types'
+import type {
+    MonodeployConfiguration,
+    PackageStrategyType,
+    StrategyDeterminer,
+} from '../types'
 
 import { readStream } from './stream'
 
@@ -80,4 +84,21 @@ export const createGetConventionalRecommendedStrategy = (
     )
 
     return conventionalStrategy?.level ?? STRATEGY.NONE
+}
+
+export const maxStrategy = async (
+    strategyA?: PackageStrategyType,
+    strategyB?: PackageStrategyType,
+): Promise<PackageStrategyType> => {
+    if (!strategyA && !strategyB) throw new Error('Invalid strategies.')
+    if (!strategyA) return strategyB as PackageStrategyType
+    if (!strategyB) return strategyA as PackageStrategyType
+
+    if (strategyA === 'major' || strategyB === 'major') {
+        return 'major'
+    }
+    if (strategyA === 'minor' || strategyB === 'minor') {
+        return 'minor'
+    }
+    return 'patch'
 }


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

- Read commit sha when reading commit messages
- Applies version strategy per commit.
- Move option defaults after CLI, so we can re-use them with the API.
- Address CR by replacing leftPad with padStart.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #213 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
