### PR TITLE
chore: move build to prepack lifecycle hook

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,7 +101,7 @@ jobs:
         - name: Install dependencies
           run: yarn install --immutable
         - name: Build
-          run: yarn build
+          run: yarn pack --filename ${ARTIFACT_DIR:-artifacts}/package.tgz
         - name: Upload Artifacts
           uses: actions/upload-artifact@v2
           with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         - name: Install dependencies
           run: yarn install --immutable
         - name: Build Package
-          run: yarn build
+          run: yarn pack --filename ${ARTIFACT_DIR:-artifacts}/package.tgz
         - name: Set Publish Credentials
           env:
             NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
             npm config set registry=https://registry.npmjs.org/
             npm config set "//registry.npmjs.org/:_authToken" "${NPM_PUBLISH_TOKEN}"
         - name: Publish Package
-          run: yarn deploy
+          run: npm publish ${ARTIFACT_DIR:-artifacts}/package.tgz --access public
         - name: Upload Artifacts
           if: ${{ always() }}
           uses: actions/upload-artifact@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ yarn test:watch
 
 ## Build
 
-You can execute `yarn build` to generate the `.tgz` package that ultimately gets uploaded to the NPM registry. It will also leave the intermediate `lib` artifacts, which contain the transpiled code.
+You can execute `yarn pack --filename artifacts/package.tgz` to generate the `.tgz` package that ultimately gets uploaded to the NPM registry. It will also leave the intermediate `lib` artifacts, which contain the transpiled code.
 
 You can use `yarn build:babel:watch` to rebuild the lib directory (minus typescript definitions) on source file change.
 

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
         "types:watch": "tsc --pretty --watch",
         "build:babel": "yarn babel src --out-dir=lib --no-copy-ignored --extensions '.ts' --ignore 'src/**/*.test.ts' --ignore 'src/**/*.mock.ts' --ignore 'src/**/__mocks__/**/*.ts'",
         "build:babel:watch": "yarn build:babel --watch",
-        "build:package": "mkdir -p ${ARTIFACT_DIR:-artifacts} && yarn pack --filename ${ARTIFACT_DIR:-artifacts}/package.tgz",
-        "build": "rm -rf lib && yarn build:babel && yarn types:generate && yarn build:package",
-        "deploy": "npm publish ${ARTIFACT_DIR:-artifacts}/package.tgz --access public",
+        "build": "rm -rf lib && yarn build:babel && yarn types:generate",
+        "prepack": "yarn build",
         "contrib:add": "all-contributors add",
         "contrib:generate": "all-contributors generate",
         "contrib:check": "all-contributors check"


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Moves build stage to prepack lifecycle hook to support installing from git source.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #217, support installing from git

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).
