### PR TITLE
build: types in devdep

### DIFF
--- a/packages/changelog/package.json
+++ b/packages/changelog/package.json
@@ -24,11 +24,11 @@
     "conventional-changelog-writer": "^5.0.0",
     "conventional-commits-parser": "^3.2.0",
     "monodeploy-io": "workspace:packages/io",
-    "monodeploy-logging": "workspace:packages/logging",
-    "monodeploy-types": "workspace:packages/types"
+    "monodeploy-logging": "workspace:packages/logging"
   },
   "devDependencies": {
     "@types/conventional-changelog-writer": "^4.0.0",
-    "@types/conventional-commits-parser": "^3.0.1"
+    "@types/conventional-commits-parser": "^3.0.1",
+    "monodeploy-types": "workspace:packages/types"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,11 +20,11 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.25",
-    "@types/yargs": "^16.0.0"
+    "@types/yargs": "^16.0.0",
+    "monodeploy-types": "workspace:packages/types"
   },
   "dependencies": {
     "monodeploy-node": "workspace:packages/node",
-    "monodeploy-types": "workspace:packages/types",
     "yargs": "^16.2.0"
   }
 }

--- a/packages/dependencies/package.json
+++ b/packages/dependencies/package.json
@@ -20,10 +20,10 @@
     "prepack": "run workspace:build \"$(pwd)\""
   },
   "dependencies": {
-    "@yarnpkg/core": "^2.4.0",
-    "monodeploy-types": "workspace:packages/types"
+    "@yarnpkg/core": "^2.4.0"
   },
   "devDependencies": {
-    "@yarnpkg/cli": "^2.4.0"
+    "@yarnpkg/cli": "^2.4.0",
+    "monodeploy-types": "workspace:packages/types"
   }
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -20,10 +20,10 @@
     "prepack": "run workspace:build \"$(pwd)\""
   },
   "devDependencies": {
-    "@types/node": "^14.14.25"
+    "@types/node": "^14.14.25",
+    "monodeploy-types": "workspace:packages/types"
   },
   "dependencies": {
-    "monodeploy-logging": "workspace:packages/logging",
-    "monodeploy-types": "workspace:packages/types"
+    "monodeploy-logging": "workspace:packages/logging"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,7 +20,8 @@
     "prepack": "run workspace:build \"$(pwd)\""
   },
   "devDependencies": {
-    "@types/node": "^14.14.14"
+    "@types/node": "^14.14.14",
+    "monodeploy-types": "workspace:packages/types"
   },
   "dependencies": {
     "@yarnpkg/cli": "^2.4.0",
@@ -34,7 +35,6 @@
     "monodeploy-io": "workspace:packages/io",
     "monodeploy-logging": "workspace:packages/logging",
     "monodeploy-publish": "workspace:packages/publish",
-    "monodeploy-types": "workspace:packages/types",
     "monodeploy-versions": "workspace:packages/versions"
   }
 }

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -27,7 +27,9 @@
     "@yarnpkg/plugin-pack": "^2.2.3",
     "monodeploy-git": "workspace:packages/git",
     "monodeploy-io": "workspace:packages/io",
-    "monodeploy-logging": "workspace:packages/logging",
+    "monodeploy-logging": "workspace:packages/logging"
+  },
+  "devDependencies": {
     "monodeploy-types": "workspace:packages/types"
   }
 }

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -30,12 +30,12 @@
     "monodeploy-git": "workspace:packages/git",
     "monodeploy-io": "workspace:packages/io",
     "monodeploy-logging": "workspace:packages/logging",
-    "monodeploy-types": "workspace:packages/types",
     "semver": "^7.3.4"
   },
   "devDependencies": {
     "@types/conventional-commits-parser": "^3.0.1",
     "@types/semver": "^7.3.4",
-    "@yarnpkg/cli": "^2.4.0"
+    "@yarnpkg/cli": "^2.4.0",
+    "monodeploy-types": "workspace:packages/types"
   }
 }


### PR DESCRIPTION
## Description

- Moves `monodeploy-types` to dev. dependencies across the board.