### PR TITLE
test: add coverage for monodeploy-changelog

### DIFF
--- a/packages/changelog/src/prependChangelogFile.test.ts
+++ b/packages/changelog/src/prependChangelogFile.test.ts
@@ -1,0 +1,148 @@
+import { promises as fs, readFileSync } from 'fs'
+
+import {
+    cleanUp,
+    createFile,
+    getMonodeployConfig,
+    setupContext,
+    setupTestRepository,
+} from '../../../testUtils'
+
+import { prependChangelogFile } from '.'
+
+describe('prependChangelogFile', () => {
+    let workspacePath
+
+    beforeEach(async () => {
+        workspacePath = await setupTestRepository()
+    })
+
+    afterEach(async () => {
+        await cleanUp([workspacePath])
+        jest.restoreAllMocks()
+    })
+
+    it('returns early if no changelogFilename is defined', async () => {
+        const cwd = workspacePath
+        const writeMock = jest.spyOn(fs, 'writeFile')
+        const readMock = jest.spyOn(fs, 'readFile')
+
+        const config = await getMonodeployConfig({
+            baseBranch: 'master',
+            commitSha: 'sha-1',
+            cwd,
+            changelogFilename: null,
+        })
+        const context = await setupContext(cwd)
+        const changeset = {
+            '1.0.0': { version: '1.0.0', changelog: 'wowchanges' },
+        }
+
+        // TODO: Better assertion.
+        await expect(async () =>
+            prependChangelogFile(config, context, changeset),
+        ).not.toThrow()
+        expect(writeMock).not.toHaveBeenCalled()
+        expect(readMock).not.toHaveBeenCalled()
+    })
+
+    it('throws if the changelog is not readable', async () => {
+        const cwd = workspacePath
+
+        // The changelog doesn't exist at the given path.
+        const config = await getMonodeployConfig({
+            baseBranch: 'master',
+            commitSha: 'sha-1',
+            cwd,
+            changelogFilename: 'changelog',
+        })
+        const context = await setupContext(cwd)
+        const changeset = {
+            '1.0.0': { version: '1.0.0', changelog: 'wowchanges' },
+        }
+
+        await expect(async () =>
+            prependChangelogFile(config, context, changeset),
+        ).rejects.toThrow()
+    })
+
+    it("throws if the changelog doesn't contain the expected marker", async () => {
+        const cwd = workspacePath
+
+        const config = await getMonodeployConfig({
+            baseBranch: 'master',
+            commitSha: 'sha-1',
+            cwd,
+            changelogFilename: 'changelog',
+        })
+        const context = await setupContext(cwd)
+        const changeset = {
+            '1.0.0': { version: '1.0.0', changelog: 'wowchanges' },
+        }
+        await createFile({ filePath: 'changelog', cwd, content: 'wonomarker' })
+        await expect(async () =>
+            prependChangelogFile(config, context, changeset),
+        ).rejects.toThrow()
+    })
+
+    it('skips writing if in dry-run mode', async () => {
+        const cwd = workspacePath
+        await createFile({
+            filePath: 'changelog',
+            cwd,
+            content: '<!-- MONODEPLOY:BELOW -->',
+        })
+        const writeMock = jest.spyOn(fs, 'writeFile')
+        const config = await getMonodeployConfig({
+            baseBranch: 'master',
+            commitSha: 'sha-1',
+            cwd,
+            changelogFilename: 'changelog',
+            dryRun: true,
+        })
+        const context = await setupContext(cwd)
+        const changeset = {
+            '1.0.0': { version: '1.0.0', changelog: 'wowchanges' },
+        }
+
+        // TODO: Better assertion.
+        await expect(async () =>
+            prependChangelogFile(config, context, changeset),
+        ).not.toThrow()
+        expect(writeMock).not.toHaveBeenCalled()
+    })
+
+    it('writes to the changelog file', async () => {
+        const cwd = workspacePath
+        const mockChangelogFilename = 'changelog'
+        const config = await getMonodeployConfig({
+            baseBranch: 'master',
+            commitSha: 'sha-1',
+            cwd,
+            changelogFilename: mockChangelogFilename,
+        })
+        const context = await setupContext(cwd)
+        await createFile({
+            filePath: 'changelog',
+            cwd: workspacePath,
+            content: '<!-- MONODEPLOY:BELOW -->',
+        })
+        const changeset = {
+            'pkg-1': {
+                version: '1.0.0',
+                changelog: 'wowchanges\nthisisachangelog',
+            },
+        }
+
+        await prependChangelogFile(config, context, changeset)
+
+        const changelogContents = readFileSync(
+            `${cwd}/${mockChangelogFilename}`,
+            { encoding: 'utf8' },
+        )
+
+        expect(changelogContents).toEqual(
+            expect.stringContaining(changeset['pkg-1'].changelog),
+        )
+    })
+})

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -25,8 +25,8 @@ describe('monodeploy-git', () => {
     it('gitDiffTree returns list of modified files', async () => {
         const cwd = tempRepositoryRoot
 
-        await createFile('test.txt', cwd)
-        await createFile('testDir/test.txt', cwd)
+        await createFile({ filePath: 'test.txt', cwd })
+        await createFile({ filePath: 'testDir/test.txt', cwd })
 
         execSync('git add . && git commit -m "test: test file" -n', {
             cwd,
@@ -48,7 +48,7 @@ describe('monodeploy-git', () => {
     it('gitResolveSha resolves HEAD properly', async () => {
         const cwd = tempRepositoryRoot
 
-        await createFile('test.txt', cwd)
+        await createFile({ filePath: 'test.txt', cwd })
         execSync('git add . && git commit -m "test: test file" -n', {
             cwd,
         })
@@ -66,7 +66,7 @@ describe('monodeploy-git', () => {
         const cwd = tempRepositoryRoot
 
         // Create some files and commit them to have a diff.
-        await createFile('test.txt', cwd)
+        await createFile({ filePath: 'test.txt', cwd })
         execSync('git commit -m "test: base" --allow-empty', {
             cwd,
         })

--- a/packages/versions/src/getExplicitVersionStrategies.test.ts
+++ b/packages/versions/src/getExplicitVersionStrategies.test.ts
@@ -29,7 +29,7 @@ describe('getExplicitVersionStrategies', () => {
         const context = await setupContext(cwd)
         await createCommit('feat: initial commit', cwd)
         execSync('git checkout -b test-branch', { cwd, stdio: 'ignore' })
-        await createFile(`packages/pkg-1/test.js`, cwd)
+        await createFile({ filePath: `packages/pkg-1/test.js`, cwd })
         const mockMessage = 'feat: woa'
         await createCommit(mockMessage, cwd)
         const headSha = execSync('git rev-parse HEAD', {

--- a/testUtils/fs.ts
+++ b/testUtils/fs.ts
@@ -1,0 +1,17 @@
+import { promises as fs } from 'fs'
+import { dirname } from 'path'
+
+export async function createFile({
+    filePath,
+    content,
+    cwd,
+}: {
+    filePath: string
+    content?: string
+    cwd: string
+}): Promise<void> {
+    const parent = dirname(filePath)
+    const fileContent = content ?? 'some content'
+    await fs.mkdir(`${cwd}/${parent}`, { recursive: true })
+    await fs.writeFile(`${cwd}/${filePath}`, fileContent)
+}

--- a/testUtils/git.ts
+++ b/testUtils/git.ts
@@ -1,9 +1,8 @@
 import { execSync } from 'child_process'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
-import { dirname, join, resolve } from 'path'
+import { join, resolve } from 'path'
 
-// TODO: Currently taken from monodeploy-git's test utils. Extract into util workspace?
 export async function setupTestRepository(): Promise<string> {
     const rootPath = await fs.mkdtemp(join(tmpdir(), 'test-repository-'))
 
@@ -25,10 +24,4 @@ export async function createCommit(
     cwd: string,
 ): Promise<void> {
     execSync(`git add . && git commit -m "${message}"`, { cwd })
-}
-
-export async function createFile(filePath: string, cwd: string): Promise<void> {
-    const parent = dirname(filePath)
-    await fs.mkdir(`${cwd}/${parent}`, { recursive: true })
-    await fs.writeFile(`${cwd}/${filePath}`, 'some_content')
 }

--- a/testUtils/index.ts
+++ b/testUtils/index.ts
@@ -1,2 +1,3 @@
 export * from './git'
 export * from './misc'
+export * from './fs'

--- a/testUtils/misc.ts
+++ b/testUtils/misc.ts
@@ -26,17 +26,17 @@ export async function setupContext(cwd: PortablePath): Promise<YarnContext> {
     return context
 }
 
-export async function getMonodeployConfig(
-    {
-        baseBranch,
-        commitSha,
-        cwd,
-        changelogFilename,
-    }: MonodeployConfiguration = { changelogFilename: 'changelog' },
-): Promise<MonodeployConfiguration> {
+export async function getMonodeployConfig({
+    baseBranch,
+    commitSha,
+    cwd,
+    changelogFilename,
+    dryRun,
+}: MonodeployConfiguration): Promise<MonodeployConfiguration> {
     return await mergeDefaultConfig({
         cwd,
         git: { baseBranch, commitSha },
         changelogFilename,
+        dryRun,
     })
 }

--- a/testUtils/misc.ts
+++ b/testUtils/misc.ts
@@ -26,13 +26,17 @@ export async function setupContext(cwd: PortablePath): Promise<YarnContext> {
     return context
 }
 
-export async function getMonodeployConfig({
-    baseBranch,
-    commitSha,
-    cwd,
-}: MonodeployConfiguration): Promise<MonodeployConfiguration> {
+export async function getMonodeployConfig(
+    {
+        baseBranch,
+        commitSha,
+        cwd,
+        changelogFilename,
+    }: MonodeployConfiguration = { changelogFilename: 'changelog' },
+): Promise<MonodeployConfiguration> {
     return await mergeDefaultConfig({
         cwd,
         git: { baseBranch, commitSha },
+        changelogFilename,
     })
 }


### PR DESCRIPTION
## Description

This adds some coverage for `monodeploy-changelog`. Writing coverage for `writeChangesetFile` is a bit trickier due to the call to `require.resolve` that is in the path of using the conventional changelog config. As such, it'll be worked off in another PR.