### PR TITLE
feat(cli): add configuration file support, close #281

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
             { additionalTestBlockFunctions: ['teste2e'] },
         ],
     },
-    ignorePatterns: ['example-monorepo/**/*', '.*', '**/*.js', '**/lib'],
+    ignorePatterns: ['.*', '**/*.js', '**/lib'],
     settings: {
         'import/parsers': {
             '@typescript-eslint/parser': ['.ts', '.js'],

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ yarn monodeploy --dry-run --log-level 0
 
 The CLI provides a few sensible defaults, however if using the Node API, you will have to provide all relevant information.
 
+You can also pass a `--config-file` flag to load options from a configuration file. The file should export an object matching the MonodeployConfiguration interface (with all properties as optional). CLI flags take precedence over the configuration file.
+
 ### Node API
 
 To use the API:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@monodeploy/node": "^0.2.1",
+    "@monodeploy/types": "^0.2.1",
     "yargs": "^16.2.0"
   }
 }

--- a/packages/cli/src/readConfigFile.ts
+++ b/packages/cli/src/readConfigFile.ts
@@ -1,0 +1,24 @@
+import { ConfigFile } from './types'
+
+const readConfigFile = async (
+    configFilename: string,
+    { cwd }: { cwd: string },
+): Promise<ConfigFile> => {
+    try {
+        const configId = require.resolve(configFilename, { paths: [cwd] })
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const config = require(configId) as ConfigFile
+        return config
+    } catch (err) {
+        if (err?.message) {
+            throw new Error(
+                `Unable to parse monodeploy config from: ${configFilename}.\n\n${err.message}`,
+            )
+        }
+
+        /* istanbul ignore next: this just surfaces the original error */
+        throw err
+    }
+}
+
+export default readConfigFile

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,24 @@
+import { MonodeployConfiguration, RecursivePartial } from '@monodeploy/types'
+
+export interface ArgOutput {
+    configFile?: string
+    registryUrl?: string
+    cwd?: string
+    dryRun?: boolean
+    gitBaseBranch?: string
+    gitCommitSha?: string
+    gitRemote?: string
+    logLevel?: number
+    conventionalChangelogConfig?: string
+    changesetFilename?: string
+    forceWriteChangeFiles?: boolean
+    prependChangelog?: string
+    access?: string
+    push?: boolean
+    persistVersions?: boolean
+    topological?: boolean
+    topologicalDev?: boolean
+    jobs?: number
+}
+
+export type ConfigFile = RecursivePartial<MonodeployConfiguration>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7784,6 +7784,7 @@ fsevents@~2.1.2:
   resolution: "monodeploy@workspace:packages/cli"
   dependencies:
     "@monodeploy/node": ^0.2.1
+    "@monodeploy/types": ^0.2.1
     "@types/node": ^14.0.0
     "@types/yargs": ^16.0.0
     yargs: ^16.2.0


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Introduces a `--config-file` flag to load config from a file.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #281, add configuration file support.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
