### PR TITLE
feat: add config option to skip registry reads and writes, close #293

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ In your monorepo's root package.json, add:
 },
 ```
 
+#### "No Registry" mode
+
+Monodeploy is an all-in-one monorepo versioning & publishing system. Although designed for publishing to NPM, you can disable all npm interactions by passing in a `--no-registry` flag to the CLI or enabling `noRegistry` in your config file. Note that this is different than enabling dry-run, in that even reads from npm are disabled. This can be useful if using monodeploy to manage a non-javascript monorepo. Just keep in mind, you'll still need to setup your project using yarn workspaces.
+
+If using "No Registry" mode, you should also enable `--persistVersions` (`persistVersions`) and commit the modified package.json files to your repository, otherwise there's no proper reference for the package versions.
+
 #### Changelog
 
 If you choose to use the `--prepend-changelog CHANGELOG.md` flag or related API config property, in your CHANGELOG.md file you'll need to insert a marker to let monodeploy know where to insert the changelog entries. For example:

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -32,7 +32,7 @@ describe('CLI', () => {
     describe('CLI Args', () => {
         it('passes cli flags to monodeploy', async () => {
             setArgs(
-                '--registry-url http://example.com --cwd /tmp --dry-run ' +
+                '--registry-url http://example.com --no-registry --cwd /tmp --dry-run ' +
                     '--git-base-branch master --git-commit-sha HEAD --git-remote origin ' +
                     '--log-level 0 --conventional-changelog-config @my/config ' +
                     '--changeset-filename changes.json --prepend-changelog changelog.md --force-write-change-files ' +
@@ -61,6 +61,7 @@ describe('CLI', () => {
                     "remote": "origin",
                   },
                   "jobs": 6,
+                  "noRegistry": true,
                   "persistVersions": true,
                   "registryUrl": "http://example.com",
                   "topological": true,
@@ -94,6 +95,7 @@ describe('CLI', () => {
                     "remote": undefined,
                   },
                   "jobs": 0,
+                  "noRegistry": undefined,
                   "persistVersions": undefined,
                   "registryUrl": undefined,
                   "topological": undefined,
@@ -179,6 +181,7 @@ describe('CLI', () => {
                     jobs: 6,
                     persistVersions: true,
                     registryUrl: 'http://example.com',
+                    noRegistry: false,
                     topological: true,
                     topologicalDev: true,
                 }
@@ -214,6 +217,7 @@ describe('CLI', () => {
                         "remote": "origin",
                       },
                       "jobs": 6,
+                      "noRegistry": false,
                       "persistVersions": true,
                       "registryUrl": "http://example.com",
                       "topological": true,
@@ -234,6 +238,7 @@ describe('CLI', () => {
                 conventionalChangelogConfig: '@my/config-from-file',
                 dryRun: true,
                 forceWriteChangeFiles: true,
+                noRegistry: false,
                 git: {
                     baseBranch: 'master',
                     commitSha: 'HEAD',
@@ -280,6 +285,7 @@ describe('CLI', () => {
                         "remote": "origin",
                       },
                       "jobs": 3,
+                      "noRegistry": false,
                       "persistVersions": true,
                       "registryUrl": "http://example.com",
                       "topological": true,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,11 @@ const { argv } = yargs
         type: 'string',
         description: 'The URL of the registry to publish to',
     })
+    .option('registry', {
+        type: 'boolean',
+        default: true,
+        description: 'Whether to read and write to the npm-like registry',
+    })
     .option('cwd', {
         type: 'string',
         description: 'Working directory',
@@ -113,6 +118,8 @@ if (argv.logLevel !== undefined && argv.logLevel !== null) {
         const config: RecursivePartial<MonodeployConfiguration> = {
             registryUrl:
                 argv.registryUrl ?? configFromFile.registryUrl ?? undefined,
+            noRegistry:
+                (!argv.registry || configFromFile.noRegistry) ?? undefined,
             cwd: cwd ?? undefined,
             dryRun: argv.dryRun ?? configFromFile.dryRun ?? undefined,
             git: {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -3,6 +3,7 @@ import { MonodeployConfiguration, RecursivePartial } from '@monodeploy/types'
 export interface ArgOutput {
     configFile?: string
     registryUrl?: string
+    registry?: boolean
     cwd?: string
     dryRun?: boolean
     gitBaseBranch?: string

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -65,8 +65,12 @@ const monodeploy = async (
         })
 
         // Determine registry
-        const registryUrl = await getRegistryUrl(config, context)
-        logging.debug(`[Config] Registry Url: ${registryUrl}`, { report })
+        const registryUrl = config.noRegistry
+            ? null
+            : await getRegistryUrl(config, context)
+        logging.debug(`[Config] Registry Url: ${String(registryUrl)}`, {
+            report,
+        })
 
         // Fetch latest package versions for workspaces
         const registryTags = await getLatestPackageTags(config, context)

--- a/packages/node/src/utils/mergeDefaultConfig.test.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.test.ts
@@ -53,6 +53,7 @@ describe('Config Merging', () => {
             cwd: '/tmp',
             registryUrl: 'https://registry.example/',
             dryRun: true,
+            noRegistry: false,
             git: {
                 baseBranch: 'master',
                 commitSha: 'HEAD',

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -11,6 +11,7 @@ const mergeDefaultConfig = async (
 
     return {
         registryUrl: baseConfig.registryUrl ?? undefined,
+        noRegistry: baseConfig.noRegistry ?? false,
         cwd,
         dryRun: baseConfig.dryRun ?? false,
         git: {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -9,6 +9,7 @@ export type RecursivePartial<T> = {
 export interface MonodeployConfiguration {
     cwd: string
     registryUrl?: string
+    noRegistry: boolean
     dryRun: boolean
     git: {
         baseBranch: string


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Adds config option to disable use of a registry.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #293, add option to disable registry access

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
