### PR TITLE
fix(publish): upload to npm the most recent package manifest

### DIFF
--- a/packages/changelog/README.md
+++ b/packages/changelog/README.md
@@ -7,4 +7,3 @@ This package is responsible for generating changelog entries, updating changelog
 ```sh
 yarn add @monodeploy/changelog
 ```
-

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,4 +15,3 @@ yarn monodeploy --cwd <PATH_TO_MONOREPO> \
     --dry-run --log-level 0 \
     --conventional-changelog-config @tophat/conventional-changelog-config
 ```
-

--- a/packages/dependencies/README.md
+++ b/packages/dependencies/README.md
@@ -7,4 +7,3 @@ This package exposes utilities to traverse a monorepo's dependency graph.
 ```sh
 yarn add @monodeploy/dependencies
 ```
-

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -7,4 +7,3 @@ This package is responsible for read/write interactions with git.
 ```sh
 yarn add @monodeploy/git
 ```
-

--- a/packages/io/README.md
+++ b/packages/io/README.md
@@ -7,4 +7,3 @@ This package provides utilities for interacting with the file system. It is an i
 ```sh
 yarn add @monodeploy/io
 ```
-

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -7,4 +7,3 @@ This package exposes utilities for logging. It is an internal package, and not i
 ```sh
 yarn add @monodeploy/logging
 ```
-

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -32,4 +32,3 @@ try {
     console.error(err)
 }
 ```
-

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -7,4 +7,3 @@ This package is responsible for the publish stage of the monodeploy pipeline, ru
 ```sh
 yarn add @monodeploy/publish
 ```
-

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -7,4 +7,3 @@ This package contains common types used across monodeploy packages.
 ```sh
 yarn add @monodeploy/types
 ```
-

--- a/packages/versions/README.md
+++ b/packages/versions/README.md
@@ -7,4 +7,3 @@ This package is responsible for determining semantic version bumps based on diff
 ```sh
 yarn add @monodeploy/versions
 ```
-


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

We need to reload the workspaces after modifying them so the `workspace.manifest.raw` value is up to date. Otherwise, when we publish to npm, we publish an _old_ version of the package.json.

