### PR TITLE
fix(git): default to HEAD^ if no tag exists on initial publish

### DIFF
--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -81,7 +81,7 @@ export const gitLastTaggedCommit = async ({
     const mostRecentTagCommand = `git describe --abbrev=0`
     logging.debug(`[Exec] ${mostRecentTagCommand}`, { report: context?.report })
 
-    let tag = 'HEAD'
+    let tag = 'HEAD^'
 
     try {
         tag = childProcess
@@ -93,7 +93,7 @@ export const gitLastTaggedCommit = async ({
             .trim()
     } catch (err) {
         logging.warning(
-            `[Exec] Fetching most recent tag failed, falling back to HEAD`,
+            `[Exec] Fetching most recent tag failed, falling back to HEAD^`,
             { report: context?.report },
         )
     }

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -138,14 +138,19 @@ describe('@monodeploy/git', () => {
     })
 
     describe('gitLastTaggedCommit', () => {
-        it('defaults to HEAD if no tag exists', async () => {
+        it('defaults to HEAD^ if no tag exists', async () => {
             const cwd = context.project.cwd
             await createFile({ filePath: 'test.txt', cwd })
             execSync('git add . && git commit -m "chore: initial commit" -n', {
                 cwd,
             })
 
-            const headSha = await gitResolveSha('HEAD', { cwd, context })
+            await createFile({ filePath: 'test1.txt', cwd })
+            execSync('git add . && git commit -m "chore: second commit" -n', {
+                cwd,
+            })
+
+            const headSha = await gitResolveSha('HEAD^', { cwd, context })
             const commit = await gitLastTaggedCommit({ cwd, context })
             expect(commit).toEqual(headSha)
         })


### PR DESCRIPTION
Otherwise "HEAD...HEAD" produces an empty diff.