### PR TITLE
feat(node): add plumbing mode for changeset data

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ module.exports = {
 }
 ```
 
+#### Preview Changes
+
+You can run:
+
+```sh
+yarn monodeploy --dry-run --changeset-filename=-
+```
+
+to implicitly disable logs and only output the changeset data. This is useful for previewing changes or determining which packages will be modified from a Pull Request.
+
 ### Node API
 
 To use the API:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "test:registry": "run test:registry:build && run test:registry:start",
         "test:watch": "run test --detectOpenHandles --watch",
         "test": "jest --detectOpenHandles",
+        "types:watch": "yarn workspaces foreach --no-private -p run types:watch",
         "workspace:build:babel:watch": "run workspace:build:babel $0 --watch",
         "workspace:build:babel": "run babel --config-file ./babel.config.js $0/src --out-dir=$0/lib --no-copy-ignored --extensions '.ts' --ignore '$0/src/**/*.test.ts' --ignore '$0/src/**/*.mock.ts' --ignore '$0/src/**/__mocks__/**/*.ts'",
         "workspace:build": "rm -rf $0/lib && run workspace:build:babel $0 && run workspace:types:generate $0",

--- a/packages/changelog/src/writeChangesetFile.ts
+++ b/packages/changelog/src/writeChangesetFile.ts
@@ -45,15 +45,21 @@ const writeChangesetFile = async (
         return changesetData
     }
 
-    const changesetPath = path.resolve(config.cwd, config.changesetFilename)
-    await fs.mkdir(path.dirname(changesetPath), { recursive: true })
+    const serializedData = JSON.stringify(changesetData, null, 2)
 
-    await fs.writeFile(changesetPath, JSON.stringify(changesetData, null, 2), {
-        encoding: 'utf8',
-    })
-    logging.info(`[Changeset] Written to: ${changesetPath}`, {
-        report: context.report,
-    })
+    if (config.changesetFilename === '-') {
+        console.log(serializedData)
+    } else {
+        const changesetPath = path.resolve(config.cwd, config.changesetFilename)
+        await fs.mkdir(path.dirname(changesetPath), { recursive: true })
+
+        await fs.writeFile(changesetPath, serializedData, {
+            encoding: 'utf8',
+        })
+        logging.info(`[Changeset] Written to: ${changesetPath}`, {
+            report: context.report,
+        })
+    }
 
     return changesetData
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -39,6 +39,12 @@ const monodeploy = async (
         throw new Error('Invalid cwd.')
     }
 
+    /**
+     * In plumbing mode, we don't want to print out any unusable logs,
+     * as it would interfere with the data intended for piping into other programs.
+     */
+    const plumbingMode = config.changesetFilename === '-'
+
     const cwd = npath.toPortablePath(path.resolve(process.cwd(), config.cwd))
     const configuration = await Configuration.find(
         cwd,
@@ -191,10 +197,10 @@ const monodeploy = async (
         {
             configuration,
             stdout: process.stdout,
-            includeLogs: true,
-            includeInfos: true,
-            includeWarnings: true,
-            includeFooter: true,
+            includeLogs: !plumbingMode,
+            includeInfos: !plumbingMode,
+            includeWarnings: !plumbingMode,
+            includeFooter: !plumbingMode,
         },
         pipeline,
     )


### PR DESCRIPTION
Adds `--changeset-filename=-` support, which disables logging and just prints the changeset data.