### PR TITLE
feat(cli): add network concurrency options to limit concurrent publishes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@monodeploy/types": "workspace:packages/types",
         "@tophat/commitizen-adapter": "^0.0.11",
         "@tophat/commitlint-config": "^0.1.2",
-        "@tophat/conventional-changelog-config": "^0.5.1",
+        "@tophat/conventional-changelog-config": "^0.5.6",
         "@tophat/eslint-config": "^0.7.0",
         "@types/jest": "^26.0.20",
         "@types/node": "^14.0.0",

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -36,7 +36,8 @@ describe('CLI', () => {
                     '--git-base-branch master --git-commit-sha HEAD --git-remote origin ' +
                     '--log-level 0 --conventional-changelog-config @my/config ' +
                     '--changeset-filename changes.json --prepend-changelog changelog.md --force-write-change-files ' +
-                    '--push --persist-versions --access public --topological --topological-dev --jobs 6',
+                    '--push --persist-versions --access public --topological --topological-dev --jobs 6 ' +
+                    '--max-concurrent-reads 3 --max-concurrent-writes 4',
             )
             jest.isolateModules(() => {
                 require('./cli')
@@ -61,6 +62,8 @@ describe('CLI', () => {
                     "remote": "origin",
                   },
                   "jobs": 6,
+                  "maxConcurrentReads": 3,
+                  "maxConcurrentWrites": 4,
                   "noRegistry": true,
                   "persistVersions": true,
                   "registryUrl": "http://example.com",
@@ -95,6 +98,8 @@ describe('CLI', () => {
                     "remote": undefined,
                   },
                   "jobs": 0,
+                  "maxConcurrentReads": 0,
+                  "maxConcurrentWrites": 0,
                   "noRegistry": undefined,
                   "persistVersions": undefined,
                   "registryUrl": undefined,
@@ -216,6 +221,8 @@ describe('CLI', () => {
                     noRegistry: false,
                     topological: true,
                     topologicalDev: true,
+                    maxConcurrentReads: 3,
+                    maxConcurrentWrites: 5,
                 }
             `
 
@@ -249,6 +256,8 @@ describe('CLI', () => {
                         "remote": "origin",
                       },
                       "jobs": 6,
+                      "maxConcurrentReads": 3,
+                      "maxConcurrentWrites": 5,
                       "noRegistry": false,
                       "persistVersions": true,
                       "registryUrl": "http://example.com",
@@ -282,6 +291,8 @@ describe('CLI', () => {
                     noRegistry: false,
                     topological: true,
                     topologicalDev: true,
+                    maxConcurrentReads: 6,
+                    maxConcurrentWrites: 2,
                 }
             `
 
@@ -316,6 +327,8 @@ describe('CLI', () => {
                         "remote": "origin",
                       },
                       "jobs": 6,
+                      "maxConcurrentReads": 6,
+                      "maxConcurrentWrites": 2,
                       "noRegistry": false,
                       "persistVersions": true,
                       "registryUrl": "http://example.com",
@@ -349,6 +362,8 @@ describe('CLI', () => {
                     noRegistry: false,
                     topological: true,
                     topologicalDev: true,
+                    maxConcurrentReads: 2,
+                    maxConcurrentWrites: 1,
                 }
             `
 
@@ -383,6 +398,8 @@ describe('CLI', () => {
                         "remote": "origin",
                       },
                       "jobs": 6,
+                      "maxConcurrentReads": 2,
+                      "maxConcurrentWrites": 1,
                       "noRegistry": false,
                       "persistVersions": true,
                       "registryUrl": "http://example.com",
@@ -416,6 +433,8 @@ describe('CLI', () => {
                 registryUrl: 'http://example.com',
                 topological: true,
                 topologicalDev: true,
+                maxConcurrentReads: 10,
+                maxConcurrentWrites: 11,
             }
         `
 
@@ -451,6 +470,8 @@ describe('CLI', () => {
                         "remote": "origin",
                       },
                       "jobs": 3,
+                      "maxConcurrentReads": 10,
+                      "maxConcurrentWrites": 11,
                       "noRegistry": false,
                       "persistVersions": true,
                       "registryUrl": "http://example.com",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -95,6 +95,18 @@ const { argv } = yargs
             'Maximum number of tasks to run in parallel (set to 0 for unbounded)',
         default: 0,
     })
+    .option('max-concurrent-writes', {
+        type: 'number',
+        description:
+            'Maximum number of concurrent requests to make when writing to the registry (set to 0 for default)',
+        defualt: 1,
+    })
+    .option('max-concurrent-reads', {
+        type: 'number',
+        description:
+            'Maximum number of concurrent requests to make when reading from the registry (set to 0 for default)',
+        defualt: 1,
+    })
     .demandCommand(0, 0)
     .strict()
     .wrap(yargs.terminalWidth()) as { argv: ArgOutput }
@@ -160,6 +172,14 @@ if (argv.logLevel !== undefined && argv.logLevel !== null) {
                 (argv.jobs && argv.jobs > 0
                     ? argv.jobs
                     : configFromFile?.jobs) ?? 0,
+            maxConcurrentReads:
+                (argv.maxConcurrentReads && argv.maxConcurrentReads > 0
+                    ? argv.maxConcurrentReads
+                    : configFromFile?.maxConcurrentReads) ?? 0,
+            maxConcurrentWrites:
+                (argv.maxConcurrentWrites && argv.maxConcurrentWrites > 0
+                    ? argv.maxConcurrentWrites
+                    : configFromFile?.maxConcurrentWrites) ?? 0,
         }
 
         await monodeploy(config)

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -20,6 +20,8 @@ export interface ArgOutput {
     topological?: boolean
     topologicalDev?: boolean
     jobs?: number
+    maxConcurrentReads?: number
+    maxConcurrentWrites?: number
 }
 
 export type ConfigFile = RecursivePartial<Omit<MonodeployConfiguration, 'cwd'>>

--- a/packages/cli/src/validateConfigFile.ts
+++ b/packages/cli/src/validateConfigFile.ts
@@ -19,6 +19,8 @@ const schema: JSONSchemaType<ConfigFile> = {
         topological: { type: 'boolean', nullable: true },
         topologicalDev: { type: 'boolean', nullable: true },
         jobs: { type: 'integer', nullable: true },
+        maxConcurrentReads: { type: 'integer', nullable: true },
+        maxConcurrentWrites: { type: 'integer', nullable: true },
         git: {
             type: 'object',
             properties: {

--- a/packages/node/src/monodeploy.test.ts
+++ b/packages/node/src/monodeploy.test.ts
@@ -79,6 +79,8 @@ describe('Monodeploy (Dry Run)', () => {
         topologicalDev: false,
         jobs: 0,
         forceWriteChangeFiles: false,
+        maxConcurrentReads: 2,
+        maxConcurrentWrites: 0,
     }
 
     beforeAll(async () => {
@@ -317,6 +319,8 @@ describe('Monodeploy', () => {
         topologicalDev: false,
         jobs: 0,
         forceWriteChangeFiles: false,
+        maxConcurrentReads: 2,
+        maxConcurrentWrites: 2,
     }
 
     beforeAll(async () => {
@@ -723,6 +727,8 @@ describe('Monodeploy Lifecycle Scripts', () => {
         topologicalDev: true,
         jobs: 100,
         forceWriteChangeFiles: false,
+        maxConcurrentReads: 4,
+        maxConcurrentWrites: 3,
     }
 
     const resolvePackagePath = (pkgName: string, filename: string) =>

--- a/packages/node/src/utils/mergeDefaultConfig.test.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.test.ts
@@ -70,6 +70,8 @@ describe('Config Merging', () => {
             topological: true,
             topologicalDev: true,
             jobs: 5,
+            maxConcurrentReads: 3,
+            maxConcurrentWrites: 2,
         }
 
         const merged = await mergeDefaultConfig(config)

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -34,6 +34,8 @@ const mergeDefaultConfig = async (
         topological: baseConfig.topological ?? false,
         topologicalDev: baseConfig.topologicalDev ?? false,
         jobs: baseConfig.jobs ?? 0,
+        maxConcurrentReads: baseConfig.maxConcurrentReads ?? 0,
+        maxConcurrentWrites: baseConfig.maxConcurrentWrites ?? 0,
     }
 }
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -26,6 +26,8 @@ export interface MonodeployConfiguration {
     topological: boolean
     topologicalDev: boolean
     jobs: number
+    maxConcurrentReads: number
+    maxConcurrentWrites: number
 }
 
 export interface YarnContext {

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -32,6 +32,7 @@
     "@yarnpkg/plugin-npm": "^2.5.0-rc.2",
     "@yarnpkg/plugin-pack": "^3.0.0-rc.2",
     "conventional-commits-parser": "^3.2.0",
+    "p-limit": "^3.1.0",
     "semver": "^7.3.4"
   },
   "devDependencies": {

--- a/packages/versions/src/versionStrategy.ts
+++ b/packages/versions/src/versionStrategy.ts
@@ -23,7 +23,7 @@ export const getDefaultRecommendedStrategy: StrategyDeterminer = async (
         conventionalCommitsParser(),
     )
     const conventionalCommits = await readStream<Commit>(commitsStream)
-    const pattern = new RegExp('^(\\w+)(\\([^:]+\\))?:.*', 'g')
+    const titlePattern = new RegExp('^(\\w+)(\\([^)]+\\))?$', 'g')
     const PATCH_TYPES = ['fix', 'perf']
     const FEATURE_TYPES = ['feat']
     const BREAKING_CHANGE = 'breaking change'
@@ -33,7 +33,7 @@ export const getDefaultRecommendedStrategy: StrategyDeterminer = async (
                 return STRATEGY.MAJOR
             }
 
-            const matches = [...note.title.matchAll(pattern)]?.[0]
+            const matches = [...note.title.matchAll(titlePattern)]?.[0]
             const type = matches?.[1]
 
             if (FEATURE_TYPES.includes(type)) {
@@ -56,6 +56,10 @@ export const getDefaultRecommendedStrategy: StrategyDeterminer = async (
             if (PATCH_TYPES.includes(commitType)) {
                 return Math.min(level, STRATEGY.PATCH)
             }
+        }
+
+        if (commit.revert) {
+            return Math.min(level, STRATEGY.PATCH)
         }
         return level
     }, STRATEGY.NONE)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,7 +1758,7 @@ __metadata:
     "@monodeploy/types": "workspace:packages/types"
     "@tophat/commitizen-adapter": ^0.0.11
     "@tophat/commitlint-config": ^0.1.2
-    "@tophat/conventional-changelog-config": ^0.5.1
+    "@tophat/conventional-changelog-config": ^0.5.6
     "@tophat/eslint-config": ^0.7.0
     "@types/jest": ^26.0.20
     "@types/node": ^14.0.0
@@ -1908,6 +1908,7 @@ __metadata:
     "@yarnpkg/plugin-npm": ^2.5.0-rc.2
     "@yarnpkg/plugin-pack": ^3.0.0-rc.2
     conventional-commits-parser: ^3.2.0
+    p-limit: ^3.1.0
     semver: ^7.3.4
   languageName: unknown
   linkType: soft
@@ -1992,17 +1993,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tophat/commit-utils-core@npm:*":
-  version: 0.5.0
-  resolution: "@tophat/commit-utils-core@npm:0.5.0"
-  checksum: 9918cab8c9a095c96279aab32010948a08e1e72992e9f3dbe13042d1db053c3b599a65f10234e114d48feae7a85cfdfd1cbb39a60ca0dbf41b81e6631b5259cd
-  languageName: node
-  linkType: hard
-
 "@tophat/commit-utils-core@npm:^0.0.9":
   version: 0.0.9
   resolution: "@tophat/commit-utils-core@npm:0.0.9"
   checksum: 3b0c5dc3bbb894114d91ff0c6a4263f419b6f0c5e49c7a2fdeddd4cfe0ec19ccd9cfec8d66ec780a47ca406c2adcd626e7fbda46fa1b89a51742bd9180d9b673
+  languageName: node
+  linkType: hard
+
+"@tophat/commit-utils-core@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@tophat/commit-utils-core@npm:0.5.4"
+  checksum: 17a9825b7b991c83c66dfdc893e6c50fee9e6ba6f4ec46c521167dbc026762c9e387d637b74129d68db82ec3f4c846d48500cd1729b2190de3711b9502edf4bd
   languageName: node
   linkType: hard
 
@@ -2027,13 +2028,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tophat/conventional-changelog-config@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "@tophat/conventional-changelog-config@npm:0.5.1"
+"@tophat/conventional-changelog-config@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@tophat/conventional-changelog-config@npm:0.5.6"
   dependencies:
-    "@tophat/commit-utils-core": "*"
+    "@tophat/commit-utils-core": ^0.5.4
     compare-func: ^2.0.0
-  checksum: 2102e3203f555f7fc3da5991f8ffab41a489a7ef217d748a54b52fb5697d5c3045b10a0d2f273199e050b623e1ca89afc0021d257e1e095d15171015f8f5eb0e
+  checksum: 353366a57670519aeb00137da1601ffdf7434e47687001d243975e412fbd1ce343ffeea2349c666f33627d5be856c54c345cf4b8365860fe4e9549a2b6e2285d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We use JFrog internally and we were maxing out the connection pool by publishing ~100 simultaneous requests to the registry.

Lerna only publishes 1 at a time.