### PR TITLE
feat(changelog): add per package changelog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Some entry.
 
 The marker `<!-- MONODEPLOY:BELOW -->` must match exactly. It is whitespace and case-sensitive.
 
+You can use the template variable `<packageDir>` to create individual changelogs per package, like so:
+
+```sh
+--prepend-changelog "<packageDir>/CHANGELOG.md"
+```
 
 ## API
 

--- a/packages/changelog/package.json
+++ b/packages/changelog/package.json
@@ -25,8 +25,10 @@
     "@monodeploy/logging": "^0.1.4",
     "@monodeploy/types": "^0.4.0",
     "@yarnpkg/core": "^3.0.0-rc.2",
+    "@yarnpkg/fslib": "^2.5.0-rc.2",
     "conventional-changelog-writer": "^5.0.0",
-    "conventional-commits-parser": "^3.2.0"
+    "conventional-commits-parser": "^3.2.0",
+    "p-limit": "^3.1.0"
   },
   "devDependencies": {
     "@monodeploy/test-utils": "link:../../testUtils",

--- a/packages/changelog/src/prependChangelogFile.ts
+++ b/packages/changelog/src/prependChangelogFile.ts
@@ -93,7 +93,7 @@ const prependChangelogFile = async (
                 npath.fromPortablePath(workspace.cwd),
             )
             const packageName = structUtils.stringifyIdent(
-                workspace.manifest.name,
+                workspace.manifest.name!,
             )
             const entry = changeset[packageName]?.changelog
             console.log(entry, packageName, changeset)

--- a/packages/changelog/src/prependChangelogFile.ts
+++ b/packages/changelog/src/prependChangelogFile.ts
@@ -1,6 +1,10 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 
+import { Workspace, structUtils } from '@yarnpkg/core'
+import { npath } from '@yarnpkg/fslib'
+import pLimit from 'p-limit'
+
 import logging from '@monodeploy/logging'
 import type {
     ChangesetSchema,
@@ -9,27 +13,38 @@ import type {
 } from '@monodeploy/types'
 
 const MARKER = '<!-- MONODEPLOY:BELOW -->'
+const TOKEN_PACKAGE_DIR = '<packageDir>'
 
-const prependChangelogFile = async (
-    config: MonodeployConfiguration,
-    context: YarnContext,
-    changeset: ChangesetSchema,
-): Promise<void> => {
-    if (!config.changelogFilename) return
-
-    const changelogFilename = path.resolve(config.cwd, config.changelogFilename)
-
+const prependEntry = async ({
+    config,
+    context,
+    filename,
+    entry,
+}: {
+    config: MonodeployConfiguration
+    context: YarnContext
+    filename: string
+    entry: string
+}): Promise<void> => {
     let changelogContents: string[] = []
     try {
         changelogContents = (
-            await fs.readFile(changelogFilename, { encoding: 'utf-8' })
+            await fs.readFile(filename, { encoding: 'utf-8' })
         ).split('\n')
     } catch (err) {
-        logging.error(
-            `[Changelog] Unable to read changelog contents at ${changelogFilename}`,
-            { report: context.report },
-        )
-        throw err
+        if (err.code === 'ENOENT') {
+            logging.info(
+                `[Changelog] Changelog ${filename} does not exist, creating.`,
+                { report: context.report },
+            )
+            changelogContents = ['# Changelog', '', MARKER]
+        } else {
+            logging.error(
+                `[Changelog] Unable to read changelog contents at ${filename}.`,
+                { report: context.report },
+            )
+            throw err
+        }
     }
 
     const changelogOffset = changelogContents.findIndex(
@@ -42,14 +57,7 @@ const prependChangelogFile = async (
         throw new Error('Unable to prepend changelog.')
     }
 
-    const newEntries = Object.entries(changeset)
-        .sort(([pkgNameA], [pkgNameB]) => pkgNameA.localeCompare(pkgNameB))
-        .map(([, changesetValue]) => changesetValue.changelog)
-        .filter(value => value)
-        .join('\n')
-        .trim()
-
-    changelogContents.splice(changelogOffset + 1, 0, `\n${newEntries}\n`)
+    changelogContents.splice(changelogOffset + 1, 0, `\n${entry}\n`)
 
     const dataToWrite = changelogContents.join('\n')
 
@@ -58,14 +66,60 @@ const prependChangelogFile = async (
             report: context.report,
         })
     } else {
-        await fs.writeFile(changelogFilename, dataToWrite, {
+        await fs.writeFile(filename, dataToWrite, {
             encoding: 'utf-8',
         })
     }
 
-    logging.info(`[Changelog] Updated ${changelogFilename}`, {
+    logging.info(`[Changelog] Updated ${filename}`, {
         report: context.report,
     })
+}
+
+const prependChangelogFile = async (
+    config: MonodeployConfiguration,
+    context: YarnContext,
+    changeset: ChangesetSchema,
+    workspaces: Set<Workspace>,
+): Promise<void> => {
+    if (!config.changelogFilename) return
+
+    if (config.changelogFilename.includes(TOKEN_PACKAGE_DIR)) {
+        const prependForWorkspace = async (
+            workspace: Workspace,
+        ): Promise<void> => {
+            const filename = config.changelogFilename!.replace(
+                TOKEN_PACKAGE_DIR,
+                npath.fromPortablePath(workspace.cwd),
+            )
+            const packageName = structUtils.stringifyIdent(
+                workspace.manifest.name,
+            )
+            const entry = changeset[packageName]?.changelog
+            console.log(entry, packageName, changeset)
+            if (entry) await prependEntry({ config, context, filename, entry })
+        }
+
+        const limit = pLimit(config.jobs || Infinity)
+        await Promise.all(
+            [...workspaces].map(workspace =>
+                limit(() => prependForWorkspace(workspace)),
+            ),
+        )
+
+        return
+    }
+
+    const filename = path.resolve(config.cwd, config.changelogFilename)
+
+    const entry = Object.entries(changeset)
+        .sort(([pkgNameA], [pkgNameB]) => pkgNameA.localeCompare(pkgNameB))
+        .map(([, changesetValue]) => changesetValue.changelog)
+        .filter(value => value)
+        .join('\n')
+        .trim()
+
+    await prependEntry({ config, context, filename, entry })
 }
 
 export default prependChangelogFile

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -168,7 +168,12 @@ const monodeploy = async (
                         versionStrategies,
                     )
 
-                    await prependChangelogFile(config, context, result)
+                    await prependChangelogFile(
+                        config,
+                        context,
+                        result,
+                        workspacesToPublish,
+                    )
                 },
             )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,8 +1695,10 @@ __metadata:
     "@types/conventional-changelog-writer": ^4.0.0
     "@types/conventional-commits-parser": ^3.0.1
     "@yarnpkg/core": ^3.0.0-rc.2
+    "@yarnpkg/fslib": ^2.5.0-rc.2
     conventional-changelog-writer: ^5.0.0
     conventional-commits-parser: ^3.2.0
+    p-limit: ^3.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Adds a `<packageDir>` token which can be used in the changelog filename to creates changelogs per package.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #285 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
