### PR TITLE
fix(changelog): do not transform commits twice

### DIFF
--- a/packages/changelog/src/changelog.ts
+++ b/packages/changelog/src/changelog.ts
@@ -122,11 +122,6 @@ const generateChangelogEntry = async (
             // NOTE: This mutates the commit.
             const mutableCommit = JSON.parse(JSON.stringify(commit))
 
-            await conventionalConfig.writerOpts?.transform?.(
-                mutableCommit,
-                templateContext,
-            )
-
             if (!mutableCommit.hash && config.git.commitSha) {
                 mutableCommit.hash = config.git.commitSha
             }


### PR DESCRIPTION
The conventional changelog writer already calls writerOpts.transform. No need to call it twice.