### PR TITLE
fix: package.json and changelog modifications were not being pushed

### DIFF
--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -100,7 +100,7 @@ export const gitPush = async ({
     context?: YarnContext
 }): Promise<void> => {
     assertProduction()
-    const gitCommand = `git push -n ${remote}`
+    const gitCommand = `git push --no-verify ${remote}`
     logging.debug(`[Exec] ${gitCommand}`, { report: context?.report })
     childProcess.execSync(gitCommand, {
         encoding: 'utf8',


### PR DESCRIPTION
If using autoCommit with git.push, the push was running dry run mode.