### PR TITLE
feat: add changeset ignore patterns support, close #346

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ module.exports = {
     conventionalChangelogConfig: '@tophat/conventional-changelog-config',
     access: 'public',
     persistVersions: false,
+    changesetIgnorePatterns: ['**/*.test.js'],
 }
 ```
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -38,7 +38,8 @@ describe('CLI', () => {
                     '--changeset-filename changes.json --prepend-changelog changelog.md --force-write-change-files ' +
                     '--push --persist-versions --access public --topological --topological-dev --jobs 6 ' +
                     '--auto-commit --auto-commit-message release --plugins plugin-a plugin-b ' +
-                    '--max-concurrent-reads 3 --max-concurrent-writes 4 --no-git-tag',
+                    '--max-concurrent-reads 3 --max-concurrent-writes 4 --no-git-tag ' +
+                    '--changeset-ignore-patterns "*.test.js"',
             )
             jest.isolateModules(() => {
                 require('./cli')
@@ -54,6 +55,9 @@ describe('CLI', () => {
                   "autoCommitMessage": "release",
                   "changelogFilename": "changelog.md",
                   "changesetFilename": "changes.json",
+                  "changesetIgnorePatterns": Array [
+                    "*.test.js",
+                  ],
                   "conventionalChangelogConfig": "@my/config",
                   "cwd": "/tmp",
                   "dryRun": true,
@@ -97,6 +101,7 @@ describe('CLI', () => {
                   "autoCommitMessage": undefined,
                   "changelogFilename": undefined,
                   "changesetFilename": undefined,
+                  "changesetIgnorePatterns": undefined,
                   "conventionalChangelogConfig": undefined,
                   "cwd": undefined,
                   "dryRun": undefined,
@@ -263,6 +268,7 @@ describe('CLI', () => {
                       "autoCommitMessage": "chore: release",
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
+                      "changesetIgnorePatterns": undefined,
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": undefined,
                       "dryRun": true,
@@ -342,6 +348,7 @@ describe('CLI', () => {
                       "autoCommitMessage": undefined,
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
+                      "changesetIgnorePatterns": undefined,
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": "/tmp/cwd",
                       "dryRun": true,
@@ -378,6 +385,7 @@ describe('CLI', () => {
                     conventionalChangelogConfig: '@my/config-from-file',
                     dryRun: true,
                     forceWriteChangeFiles: true,
+                    changesetIgnorePatterns: ['*.test.js', '*.snap'],
                     git: {
                         baseBranch: 'master',
                         commitSha: 'HEAD',
@@ -418,6 +426,10 @@ describe('CLI', () => {
                       "autoCommitMessage": undefined,
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
+                      "changesetIgnorePatterns": Array [
+                        "*.test.js",
+                        "*.snap",
+                      ],
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": "/tmp/cwd",
                       "dryRun": true,
@@ -497,6 +509,7 @@ describe('CLI', () => {
                       "autoCommitMessage": "chore: release",
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
+                      "changesetIgnorePatterns": undefined,
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": undefined,
                       "dryRun": true,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -125,6 +125,11 @@ const { argv } = yargs
         type: 'array',
         description: 'Monodeploy plugins',
     })
+    .option('changeset-ignore-patterns', {
+        type: 'array',
+        description:
+            'Globs to use in filtering out files when determining version bumps',
+    })
     .demandCommand(0, 0)
     .strict()
     .wrap(yargs.terminalWidth()) as { argv: ArgOutput }
@@ -176,6 +181,10 @@ if (argv.logLevel !== undefined && argv.logLevel !== null) {
             changesetFilename:
                 argv.changesetFilename ??
                 configFromFile?.changesetFilename ??
+                undefined,
+            changesetIgnorePatterns:
+                argv.changesetIgnorePatterns ??
+                configFromFile?.changesetIgnorePatterns ??
                 undefined,
             changelogFilename:
                 argv.prependChangelog ??

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -26,6 +26,7 @@ export interface ArgOutput {
     maxConcurrentReads?: number
     maxConcurrentWrites?: number
     plugins?: Array<string>
+    changesetIgnorePatterns?: Array<string>
 }
 
 export type ConfigFile = RecursivePartial<Omit<MonodeployConfiguration, 'cwd'>>

--- a/packages/cli/src/validateConfigFile.ts
+++ b/packages/cli/src/validateConfigFile.ts
@@ -13,6 +13,11 @@ const schema: JSONSchemaType<ConfigFile> = {
         conventionalChangelogConfig: { type: 'string', nullable: true },
         changesetFilename: { type: 'string', nullable: true },
         changelogFilename: { type: 'string', nullable: true },
+        changesetIgnorePatterns: {
+            type: 'array',
+            nullable: true,
+            items: { type: 'string' },
+        },
         forceWriteChangeFiles: { type: 'boolean', nullable: true },
         access: { type: 'string', nullable: true },
         persistVersions: { type: 'boolean', nullable: true },

--- a/packages/node/src/utils/mergeDefaultConfig.test.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.test.ts
@@ -64,6 +64,7 @@ describe('Config Merging', () => {
                 '@tophat/conventional-changelog-config',
             changesetFilename: '/tmp/changeset.json',
             changelogFilename: '/tmp/changelog.md',
+            changesetIgnorePatterns: ['*.md'],
             forceWriteChangeFiles: false,
             access: 'public',
             persistVersions: true,

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -29,6 +29,7 @@ const mergeDefaultConfig = async (
             baseConfig.conventionalChangelogConfig ?? undefined,
         changesetFilename: baseConfig.changesetFilename ?? undefined,
         changelogFilename: baseConfig.changelogFilename ?? undefined,
+        changesetIgnorePatterns: baseConfig.changesetIgnorePatterns ?? [],
         forceWriteChangeFiles: baseConfig.forceWriteChangeFiles ?? false,
         access: baseConfig.access ?? 'public',
         persistVersions: baseConfig.persistVersions ?? false,

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -32,12 +32,14 @@
     "@yarnpkg/plugin-npm": "^2.5.0-rc.5",
     "@yarnpkg/plugin-pack": "^3.0.0-rc.5",
     "conventional-commits-parser": "^3.2.0",
+    "micromatch": "^4.0.4",
     "p-limit": "^3.1.0",
     "semver": "^7.3.4"
   },
   "devDependencies": {
     "@monodeploy/test-utils": "link:../../testUtils",
     "@types/conventional-commits-parser": "^3.0.1",
+    "@types/micromatch": "^4",
     "@types/semver": "^7.3.4",
     "@yarnpkg/cli": "^3.0.0-rc.5"
   }

--- a/packages/versions/src/getExplicitVersionStrategies.test.ts
+++ b/packages/versions/src/getExplicitVersionStrategies.test.ts
@@ -58,4 +58,46 @@ describe('getExplicitVersionStrategies', () => {
             ]),
         )
     })
+
+    it('ignores ignored files', async () => {
+        const cwd = tempRepositoryRoot
+        const context = await setupContext(cwd as PortablePath)
+        await createCommit('feat: initial commit', cwd)
+        execSync('git checkout -b test-branch', { cwd, stdio: 'ignore' })
+
+        await createFile({ filePath: `packages/pkg-1/test.js`, cwd })
+        await createFile({ filePath: `packages/pkg-2/test.test.js`, cwd })
+
+        const mockMessage = 'feat: woa'
+        await createCommit(mockMessage, cwd)
+        const headSha = execSync('git rev-parse HEAD', {
+            cwd,
+            encoding: 'utf8',
+        }).trim()
+
+        const strategies = await getExplicitVersionStrategies({
+            config: {
+                ...(await getMonodeployConfig({
+                    cwd,
+                    commitSha: headSha,
+                    baseBranch: 'master',
+                })),
+                changesetIgnorePatterns: ['**/*.test.js', '**/*.md'],
+            },
+            context,
+        })
+
+        expect(strategies.has('pkg-2')).toBe(false)
+        expect(strategies).toEqual(
+            new Map([
+                [
+                    'pkg-1',
+                    {
+                        commits: [{ body: `${mockMessage}\n\n`, sha: headSha }],
+                        type: 'minor',
+                    },
+                ],
+            ]),
+        )
+    })
 })

--- a/packages/versions/src/getExplicitVersionStrategies.ts
+++ b/packages/versions/src/getExplicitVersionStrategies.ts
@@ -10,6 +10,7 @@ import type {
 } from '@monodeploy/types'
 import { structUtils } from '@yarnpkg/core'
 import { PortablePath } from '@yarnpkg/fslib'
+import micromatch from 'micromatch'
 
 import {
     STRATEGY,
@@ -26,11 +27,15 @@ const strategyLevelToType = (level: number): PackageStrategyType | null => {
     return (name as PackageStrategyType | null) ?? null
 }
 
-const getModifiedPackages = async (
-    config: MonodeployConfiguration,
-    context: YarnContext,
-    commitSha: string,
-): Promise<string[]> => {
+const getModifiedPackages = async ({
+    config,
+    context,
+    commitSha,
+}: {
+    config: MonodeployConfiguration
+    context: YarnContext
+    commitSha: string
+}): Promise<string[]> => {
     const diffOutput = await gitDiffTree(commitSha, {
         cwd: config.cwd,
         context,
@@ -44,20 +49,24 @@ const getModifiedPackages = async (
         new Set(),
     )
 
+    const ignorePatterns = config.changesetIgnorePatterns ?? []
+
     const modifiedPackages = [...uniquePaths].reduce(
         (modifiedPackages: string[], currentPath: string): string[] => {
-            try {
-                const workspace = context.project.getWorkspaceByFilePath(
-                    path.resolve(config.cwd, currentPath) as PortablePath,
-                )
-                const ident = workspace?.manifest?.name
-                if (!ident) throw new Error('Missing workspace identity.')
-                const packageName = structUtils.stringifyIdent(ident)
-                if (packageName && !workspace.manifest.private) {
-                    modifiedPackages.push(packageName)
+            if (!micromatch([currentPath], ignorePatterns).length) {
+                try {
+                    const workspace = context.project.getWorkspaceByFilePath(
+                        path.resolve(config.cwd, currentPath) as PortablePath,
+                    )
+                    const ident = workspace?.manifest?.name
+                    if (!ident) throw new Error('Missing workspace identity.')
+                    const packageName = structUtils.stringifyIdent(ident)
+                    if (packageName && !workspace.manifest.private) {
+                        modifiedPackages.push(packageName)
+                    }
+                } catch (e) {
+                    logging.error(e, { report: context.report })
                 }
-            } catch (e) {
-                logging.error(e, { report: context.report })
             }
             return modifiedPackages
         },
@@ -83,11 +92,11 @@ const getExplicitVersionStrategies = async ({
         const strategy = strategyLevelToType(
             await strategyDeterminer([commit.body]),
         )
-        const packageNames = await getModifiedPackages(
+        const packageNames = await getModifiedPackages({
             config,
             context,
-            commit.sha,
-        )
+            commitSha: commit.sha,
+        })
 
         for (const pkgName of packageNames) {
             if (!strategy) continue

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,15 +850,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monodeploy/changelog@^0.5.3, @monodeploy/changelog@workspace:packages/changelog":
+"@monodeploy/changelog@^0.5.4, @monodeploy/changelog@workspace:packages/changelog":
   version: 0.0.0-use.local
   resolution: "@monodeploy/changelog@workspace:packages/changelog"
   dependencies:
-    "@monodeploy/git": ^0.2.2
-    "@monodeploy/io": ^0.2.9
-    "@monodeploy/logging": ^0.1.4
+    "@monodeploy/git": ^0.2.3
+    "@monodeploy/io": ^0.2.10
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.5.0
+    "@monodeploy/types": ^0.6.0
     "@types/conventional-changelog-writer": ^4.0.0
     "@types/conventional-commits-parser": ^3.0.1
     "@yarnpkg/core": ^3.0.0-rc.5
@@ -869,24 +869,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/dependencies@npm:^0.2.7":
-  version: 0.2.7
-  resolution: "@monodeploy/dependencies@npm:0.2.7"
-  dependencies:
-    "@monodeploy/logging": ^0.1.4
-    "@monodeploy/types": ^0.5.0
-    "@yarnpkg/core": ^3.0.0-rc.2
-  checksum: ade6ceaaa5c07d239df60f4c126d6204d2e617dbd5ccddfda5e78c08006eba7c88751e8851eb11ee9436f69ab7c4c9b79bbda45f016de5028c448301296c1c80
-  languageName: node
-  linkType: hard
-
-"@monodeploy/dependencies@workspace:packages/dependencies":
+"@monodeploy/dependencies@^0.2.8, @monodeploy/dependencies@workspace:packages/dependencies":
   version: 0.0.0-use.local
   resolution: "@monodeploy/dependencies@workspace:packages/dependencies"
   dependencies:
-    "@monodeploy/logging": ^0.1.4
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.4.0
+    "@monodeploy/types": ^0.6.0
     "@yarnpkg/core": ^3.0.0-rc.5
     "@yarnpkg/fslib": ^2.5.0-rc.5
   languageName: unknown
@@ -905,44 +894,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/git@^0.2.2, @monodeploy/git@workspace:packages/git":
+"@monodeploy/git@^0.2.3, @monodeploy/git@workspace:packages/git":
   version: 0.0.0-use.local
   resolution: "@monodeploy/git@workspace:packages/git"
   dependencies:
-    "@monodeploy/logging": ^0.1.4
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.5.0
+    "@monodeploy/types": ^0.6.0
     "@types/node": ^14.0.0
     "@yarnpkg/core": ^3.0.0-rc.5
   languageName: unknown
   linkType: soft
 
-"@monodeploy/io@npm:^0.2.9":
-  version: 0.2.9
-  resolution: "@monodeploy/io@npm:0.2.9"
-  dependencies:
-    "@monodeploy/logging": ^0.1.4
-    "@monodeploy/types": ^0.5.0
-    "@yarnpkg/core": ^3.0.0-rc.2
-    "@yarnpkg/fslib": ^2.5.0-rc.2
-  checksum: 9d7731210c9746b89ca882a91c9954784f7f3d51cff3d2f3d853a8ce1089de2a6e29314cd2d58254abc41ce5648a47034984c8fac341e7eecac612f10ac94aa6
-  languageName: node
-  linkType: hard
-
-"@monodeploy/io@workspace:packages/io":
+"@monodeploy/io@^0.2.10, @monodeploy/io@workspace:packages/io":
   version: 0.0.0-use.local
   resolution: "@monodeploy/io@workspace:packages/io"
   dependencies:
-    "@monodeploy/logging": ^0.1.4
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.4.0
+    "@monodeploy/types": ^0.6.0
     "@types/node": ^14.0.0
     "@yarnpkg/core": ^3.0.0-rc.5
     "@yarnpkg/fslib": ^2.5.0-rc.5
   languageName: unknown
   linkType: soft
 
-"@monodeploy/logging@^0.1.4, @monodeploy/logging@workspace:packages/logging":
+"@monodeploy/logging@^0.1.5, @monodeploy/logging@workspace:packages/logging":
   version: 0.0.0-use.local
   resolution: "@monodeploy/logging@workspace:packages/logging"
   dependencies:
@@ -1000,18 +977,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/node@^0.8.5, @monodeploy/node@workspace:packages/node":
+"@monodeploy/node@^0.8.6, @monodeploy/node@workspace:packages/node":
   version: 0.0.0-use.local
   resolution: "@monodeploy/node@workspace:packages/node"
   dependencies:
-    "@monodeploy/changelog": ^0.5.3
-    "@monodeploy/git": ^0.2.2
-    "@monodeploy/io": ^0.2.9
-    "@monodeploy/logging": ^0.1.4
-    "@monodeploy/publish": ^0.4.4
+    "@monodeploy/changelog": ^0.5.4
+    "@monodeploy/git": ^0.2.3
+    "@monodeploy/io": ^0.2.10
+    "@monodeploy/logging": ^0.1.5
+    "@monodeploy/publish": ^0.4.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.5.0
-    "@monodeploy/versions": ^0.4.5
+    "@monodeploy/types": ^0.6.0
+    "@monodeploy/versions": ^0.4.6
     "@types/node": ^14.0.0
     "@yarnpkg/cli": ^3.0.0-rc.5
     "@yarnpkg/core": ^3.0.0-rc.5
@@ -1026,10 +1003,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@monodeploy/plugin-github@workspace:packages/plugin-github"
   dependencies:
-    "@monodeploy/git": ^0.2.2
-    "@monodeploy/logging": ^0.1.4
+    "@monodeploy/git": ^0.2.3
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.5.0
+    "@monodeploy/types": ^0.6.0
     "@octokit/core": ^3.4.0
     "@octokit/plugin-throttling": ^3.4.1
     "@types/node": ^14.0.0
@@ -1037,16 +1014,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/publish@^0.4.4, @monodeploy/publish@workspace:packages/publish":
+"@monodeploy/publish@^0.4.5, @monodeploy/publish@workspace:packages/publish":
   version: 0.0.0-use.local
   resolution: "@monodeploy/publish@workspace:packages/publish"
   dependencies:
-    "@monodeploy/dependencies": ^0.2.7
-    "@monodeploy/git": ^0.2.2
-    "@monodeploy/io": ^0.2.9
-    "@monodeploy/logging": ^0.1.4
+    "@monodeploy/dependencies": ^0.2.8
+    "@monodeploy/git": ^0.2.3
+    "@monodeploy/io": ^0.2.10
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.5.0
+    "@monodeploy/types": ^0.6.0
     "@yarnpkg/cli": ^3.0.0-rc.5
     "@yarnpkg/core": ^3.0.0-rc.5
     "@yarnpkg/fslib": ^2.5.0-rc.5
@@ -1116,7 +1093,7 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@monodeploy/types@^0.4.0, @monodeploy/types@workspace:packages/types":
+"@monodeploy/types@^0.6.0, @monodeploy/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@monodeploy/types@workspace:packages/types"
   dependencies:
@@ -1125,27 +1102,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/types@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@monodeploy/types@npm:0.5.0"
-  dependencies:
-    "@yarnpkg/core": ^3.0.0-rc.2
-    tapable: ^2.2.0
-  checksum: 0b43bbde4a0beefc7096a7b0e40fbfc6a535b136776e2b212eaa632d490bbf9662738f6bec2a23ef9deba92f4e506d5702ba2f94099395427c702ff8fe8d1ed3
-  languageName: node
-  linkType: hard
-
-"@monodeploy/versions@^0.4.5, @monodeploy/versions@workspace:packages/versions":
+"@monodeploy/versions@^0.4.6, @monodeploy/versions@workspace:packages/versions":
   version: 0.0.0-use.local
   resolution: "@monodeploy/versions@workspace:packages/versions"
   dependencies:
-    "@monodeploy/dependencies": ^0.2.7
-    "@monodeploy/git": ^0.2.2
-    "@monodeploy/io": ^0.2.9
-    "@monodeploy/logging": ^0.1.4
+    "@monodeploy/dependencies": ^0.2.8
+    "@monodeploy/git": ^0.2.3
+    "@monodeploy/io": ^0.2.10
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": ^0.5.0
+    "@monodeploy/types": ^0.6.0
     "@types/conventional-commits-parser": ^3.0.1
+    "@types/micromatch": ^4
     "@types/semver": ^7.3.4
     "@yarnpkg/cli": ^3.0.0-rc.5
     "@yarnpkg/core": ^3.0.0-rc.5
@@ -1153,6 +1121,7 @@ __metadata:
     "@yarnpkg/plugin-npm": ^2.5.0-rc.5
     "@yarnpkg/plugin-pack": ^3.0.0-rc.5
     conventional-commits-parser: ^3.2.0
+    micromatch: ^4.0.4
     p-limit: ^3.1.0
     semver: ^7.3.4
   languageName: unknown
@@ -1458,6 +1427,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/braces@npm:*":
+  version: 3.0.0
+  resolution: "@types/braces@npm:3.0.0"
+  checksum: 4f2a99b04cd5141d2c64051e002447c6ef243dc90855b5293c4f3b02ca65435c7ed1ae647497ff0f253fbf0105af31b7190ebbe88e121b1c435f3c58cacc96df
+  languageName: node
+  linkType: hard
+
 "@types/cacheable-request@npm:^6.0.1":
   version: 6.0.1
   resolution: "@types/cacheable-request@npm:6.0.1"
@@ -1581,6 +1557,15 @@ __metadata:
   version: 4.14.170
   resolution: "@types/lodash@npm:4.14.170"
   checksum: 238a440804e787b85461cc280a11926c80779f7502fec21a70b4424d5feba4cc34cdcbbbc1dca2ec5e75b06d5dc42e42add798be3b6651e8dce9f4b5318d6022
+  languageName: node
+  linkType: hard
+
+"@types/micromatch@npm:^4":
+  version: 4.0.1
+  resolution: "@types/micromatch@npm:4.0.1"
+  dependencies:
+    "@types/braces": "*"
+  checksum: 4f9fea285778c579055c83fbb025f576c3adc9541ec89e12f1e192e53c0885a04d1a5863b44001606f01964f12b26f8b08b033c06de11ca9de78d58e7a672850
   languageName: node
   linkType: hard
 
@@ -1818,7 +1803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/core@npm:^3.0.0-rc.2, @yarnpkg/core@npm:^3.0.0-rc.5":
+"@yarnpkg/core@npm:^3.0.0-rc.5":
   version: 3.0.0-rc.5
   resolution: "@yarnpkg/core@npm:3.0.0-rc.5"
   dependencies:
@@ -1858,7 +1843,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/fslib@npm:^2.5.0-rc.2, @yarnpkg/fslib@npm:^2.5.0-rc.5":
+"@yarnpkg/fslib@npm:^2.5.0-rc.5":
   version: 2.5.0-rc.5
   resolution: "@yarnpkg/fslib@npm:2.5.0-rc.5"
   dependencies:
@@ -6799,8 +6784,8 @@ fsevents@^2.3.2:
   version: 0.0.0-use.local
   resolution: "monodeploy@workspace:packages/cli"
   dependencies:
-    "@monodeploy/node": ^0.8.5
-    "@monodeploy/types": ^0.5.0
+    "@monodeploy/node": ^0.8.6
+    "@monodeploy/types": ^0.6.0
     "@types/node": ^14.0.0
     "@types/yargs": ^16.0.0
     ajv: ^8.1.0


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Using the changesetIgnorePatterns config option, it is now possible to exclude files (via glob) from consideration when determining packages to apply version bump strategies to.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #346

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
