### PR TITLE
fix: do not generate changelog for dependent packages

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@monodeploy/e2e-tests",
+    "private": true,
     "scripts": {
         "test:registry:build": "docker build -t monodeploy-test-registry .",
         "test:registry:logs": "docker container logs -f monodeploy-registry",

--- a/e2e-tests/tests/full.test.ts
+++ b/e2e-tests/tests/full.test.ts
@@ -65,12 +65,12 @@ describe('Full E2E', () => {
                         version: '0.1.0',
                     }),
                     'pkg-2': expect.objectContaining({
-                        changelog: expect.not.stringContaining('fancy'),
+                        changelog: null,
                         tag: 'pkg-2@0.0.1',
                         version: '0.0.1',
                     }),
                     'pkg-3': expect.objectContaining({
-                        changelog: expect.not.stringContaining('fancy'),
+                        changelog: null,
                         tag: 'pkg-3@0.0.1',
                         version: '0.0.1',
                     }),
@@ -123,12 +123,12 @@ describe('Full E2E', () => {
                         version: '1.0.0',
                     }),
                     'pkg-3': expect.objectContaining({
-                        changelog: expect.not.stringContaining('breaking'),
+                        changelog: null,
                         tag: 'pkg-3@0.0.2',
                         version: '0.0.2',
                     }),
                     'pkg-4': expect.objectContaining({
-                        changelog: expect.not.stringContaining('breaking'),
+                        changelog: null,
                         tag: 'pkg-4@0.0.1',
                         version: '0.0.1',
                     }),

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "lint:fix": "eslint . --fix",
         "lint": "eslint .",
         "test:ci": "CI=1 run test --ci",
-        "test:watch": "run test --detectOpenHandles --watch",
+        "test:watch": "run test --watch ./packages",
         "test": "jest ./packages",
         "test:all": "yarn test:ci && yarn test:e2e && yarn test:coverage:merge && yarn test:coverage:report",
         "test:e2e": "E2E=1 yarn workspace @monodeploy/e2e-tests run test",

--- a/packages/changelog/src/changelog.ts
+++ b/packages/changelog/src/changelog.ts
@@ -30,6 +30,10 @@ const generateChangelogEntry = async ({
         return null
     }
 
+    if (!commits.length) {
+        return null
+    }
+
     const ident = structUtils.parseIdent(packageName)
     const workspace = context.project.getWorkspaceByIdent(ident)
 

--- a/packages/node/src/tests/main.test.ts
+++ b/packages/node/src/tests/main.test.ts
@@ -266,15 +266,11 @@ describe('Monodeploy', () => {
 
         // pkg-3 depends on pkg-2, and is updated as dependent
         expect(result['pkg-3'].version).toEqual('0.0.2')
-        expect(result['pkg-3'].changelog).not.toEqual(
-            expect.stringContaining('some new feature'),
-        )
+        expect(result['pkg-3'].changelog).toBeNull()
 
         // pkg-6 depends on pkg-3, and is updated as a transitive dependent
         expect(result['pkg-6'].version).toEqual('0.0.2')
-        expect(result['pkg-6'].changelog).not.toEqual(
-            expect.stringContaining('some new feature'),
-        )
+        expect(result['pkg-6'].changelog).toBeNull()
 
         // Not tags pushed in dry run
         expect(mockGit._getPushedTags_()).toEqual([
@@ -315,18 +311,11 @@ describe('Monodeploy', () => {
 
         // pkg-3 depends on pkg-2
         expect(result['pkg-3'].version).toEqual('0.0.2')
-        expect(result['pkg-3'].changelog).not.toEqual(
-            expect.stringContaining('some new feature'),
-        )
-        expect(result['pkg-3'].changelog).not.toEqual(
-            expect.stringContaining('a different fix'),
-        )
+        expect(result['pkg-3'].changelog).toBeNull()
 
         // pkg-6 depends on pkg-3, and is updated as a transitive dependent
         expect(result['pkg-6'].version).toEqual('0.0.2')
-        expect(result['pkg-6'].changelog).not.toEqual(
-            expect.stringContaining('some new feature'),
-        )
+        expect(result['pkg-6'].changelog).toBeNull()
 
         expect(mockGit._getPushedTags_()).toEqual([
             'pkg-1@0.1.0',

--- a/packages/plugin-github/src/index.ts
+++ b/packages/plugin-github/src/index.ts
@@ -41,6 +41,16 @@ const GitHubPlugin = ({
                     throw new Error(`Missing package git tag for ${pkgName}`)
                 }
 
+                if (!changeData.changelog) {
+                    logging.info(
+                        `[${PluginName}] Skipping release for ${changeData.tag} as there's no changelog.`,
+                        {
+                            report: context.report,
+                        },
+                    )
+                    continue
+                }
+
                 logging.info(
                     `[${PluginName}] Creating release for ${changeData.tag}`,
                     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,7 +977,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/node@^0.8.6, @monodeploy/node@workspace:packages/node":
+"@monodeploy/node@^0.9.0, @monodeploy/node@workspace:packages/node":
   version: 0.0.0-use.local
   resolution: "@monodeploy/node@workspace:packages/node"
   dependencies:
@@ -988,7 +988,7 @@ __metadata:
     "@monodeploy/publish": ^0.4.5
     "@monodeploy/test-utils": "link:../../testUtils"
     "@monodeploy/types": ^0.6.0
-    "@monodeploy/versions": ^0.4.6
+    "@monodeploy/versions": ^0.5.0
     "@types/node": ^14.0.0
     "@yarnpkg/cli": ^3.0.0-rc.5
     "@yarnpkg/core": ^3.0.0-rc.5
@@ -1102,7 +1102,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/versions@^0.4.6, @monodeploy/versions@workspace:packages/versions":
+"@monodeploy/versions@^0.5.0, @monodeploy/versions@workspace:packages/versions":
   version: 0.0.0-use.local
   resolution: "@monodeploy/versions@workspace:packages/versions"
   dependencies:
@@ -6784,7 +6784,7 @@ fsevents@^2.3.2:
   version: 0.0.0-use.local
   resolution: "monodeploy@workspace:packages/cli"
   dependencies:
-    "@monodeploy/node": ^0.8.6
+    "@monodeploy/node": ^0.9.0
     "@monodeploy/types": ^0.6.0
     "@types/node": ^14.0.0
     "@types/yargs": ^16.0.0


### PR DESCRIPTION
## Description

Stop generating changelogs dependents as they make it hard to find the "real" changes in changelogs and GitHub releases. We still publish the tag, so it shows up on the GitHub releases page, but no longer in some h1 header.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #355

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
