### PR TITLE
fix: do not update devDependencies when patching package.jsons

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -255,7 +255,8 @@ jobs:
               --git-base-branch origin/${{ github.base_ref }} \
               --conventional-changelog-config @tophat/conventional-changelog-config \
               --prepend-changelog ${{ env.ARTIFACT_DIR }}/CHANGELOG.md \
-              --force-write-change-files
+              --force-write-change-files \
+              --changeset-ignore-patterns '**/*.test.ts'
 
             changelog_body=$(cat ${{ env.ARTIFACT_DIR }}/CHANGELOG.md)
             changelog_body="${changelog_body//'%'/'%25'}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
               --dry-run \
               --log-level 0 \
               --conventional-changelog-config @tophat/conventional-changelog-config \
-              --prepend-changelog ./CHANGELOG.md
+              --prepend-changelog ./CHANGELOG.md \
+              --changeset-ignore-patterns '**/*.test.ts'
             git status
             git --no-pager diff
   release:
@@ -100,7 +101,8 @@ jobs:
               --auto-commit \
               --auto-commit-message "chore: release monodeploy [skip ci]" \
               --plugins "@monodeploy/plugin-github" \
-              --push
+              --push \
+              --changeset-ignore-patterns '**/*.test.ts'
         - name: Upload Artifacts
           uses: actions/upload-artifact@v2
           with:

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,5 +43,6 @@ module.exports = {
     },
     modulePathIgnorePatterns: [
         "<rootDir>/.*/lib"
-    ]
+    ],
+    testTimeout: 10000,
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "nyc": "^15.1.0",
         "prettier": "^2.3.0",
         "querystring": "^0.2.1",
-        "ts-jest": "^27.0.2",
+        "ts-jest": "^27.0.3",
         "ts-node": "^10.0.0",
         "typescript": "~4.2.4",
         "yaml-validator": "^3.0.1"

--- a/packages/io/src/patchPackageJsons.ts
+++ b/packages/io/src/patchPackageJsons.ts
@@ -26,7 +26,7 @@ const patchPackageJsons = async (
         if (!version) throw new Error(`${pkgName} is missing a version`)
 
         workspace.manifest.version = version
-        for (const dependentSetKey of Manifest.allDependencies) {
+        for (const dependentSetKey of ['dependencies', 'peerDependencies']) {
             const dependencySet =
                 workspace.manifest.getForScope(dependentSetKey)
 

--- a/packages/versions/src/applyReleases.test.ts
+++ b/packages/versions/src/applyReleases.test.ts
@@ -32,7 +32,7 @@ describe('applyReleases', () => {
                 'pkg-2': { dependencies: ['pkg-1'] },
                 'pkg-3': {
                     peerDependencies: ['pkg-2'],
-                    devDependencies: ['pkg-1'],
+                    dependencies: ['pkg-1'],
                 },
             },
             async (context) => {
@@ -89,7 +89,7 @@ describe('applyReleases', () => {
 
                 // pkg-1 again should not be changed from registry tags
                 expect(
-                    manifest3.devDependencies.get(
+                    manifest3.dependencies.get(
                         workspace1.manifest.name!.identHash,
                     )!.range,
                 ).toEqual(`^1.0.0`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,7 +850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monodeploy/changelog@^0.5.4, @monodeploy/changelog@workspace:packages/changelog":
+"@monodeploy/changelog@^0.5.5, @monodeploy/changelog@workspace:packages/changelog":
   version: 0.0.0-use.local
   resolution: "@monodeploy/changelog@workspace:packages/changelog"
   dependencies:
@@ -970,18 +970,18 @@ __metadata:
     nyc: ^15.1.0
     prettier: ^2.3.0
     querystring: ^0.2.1
-    ts-jest: ^27.0.2
+    ts-jest: ^27.0.3
     ts-node: ^10.0.0
     typescript: ~4.2.4
     yaml-validator: ^3.0.1
   languageName: unknown
   linkType: soft
 
-"@monodeploy/node@^0.9.0, @monodeploy/node@workspace:packages/node":
+"@monodeploy/node@^0.9.1, @monodeploy/node@workspace:packages/node":
   version: 0.0.0-use.local
   resolution: "@monodeploy/node@workspace:packages/node"
   dependencies:
-    "@monodeploy/changelog": ^0.5.4
+    "@monodeploy/changelog": ^0.5.5
     "@monodeploy/git": ^0.2.3
     "@monodeploy/io": ^0.2.10
     "@monodeploy/logging": ^0.1.5
@@ -6784,7 +6784,7 @@ fsevents@^2.3.2:
   version: 0.0.0-use.local
   resolution: "monodeploy@workspace:packages/cli"
   dependencies:
-    "@monodeploy/node": ^0.9.0
+    "@monodeploy/node": ^0.9.1
     "@monodeploy/types": ^0.6.0
     "@types/node": ^14.0.0
     "@types/yargs": ^16.0.0
@@ -8886,9 +8886,9 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^27.0.2":
-  version: 27.0.2
-  resolution: "ts-jest@npm:27.0.2"
+"ts-jest@npm:^27.0.3":
+  version: 27.0.3
+  resolution: "ts-jest@npm:27.0.3"
   dependencies:
     bs-logger: 0.x
     buffer-from: 1.x
@@ -8905,7 +8905,7 @@ resolve@^2.0.0-next.3:
     typescript: ">=3.8 <5.0"
   bin:
     ts-jest: cli.js
-  checksum: dbc3fb1e61b6fc4c4063c32e8637bd2a255e8e54f0388ddd67064b712c796e9523697ec9d74a7563ce04117f4771f29e3b2a87cd5a455645808af877a7fba96a
+  checksum: 197f6722e3182de40223d6c7a87fbee06dec5e20748365497f081179bf00e4d95ed5e479d1d9b006752701f0353cb0cc1e16b8b54ffdf83335e5010f642d28b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
devDependencies do not need to be updated as they are not used externally, and therefore have no impact on the public API and behaviour
