### PR TITLE
fix: plugin-github should declare monodeploy dependencies

### DIFF
--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -21,20 +21,15 @@
     "prepack": "run workspace:build \"$(pwd)\""
   },
   "devDependencies": {
-    "@monodeploy/git": "workspace:*",
-    "@monodeploy/logging": "workspace:*",
     "@monodeploy/test-utils": "link:../../testUtils",
-    "@monodeploy/types": "workspace:*",
     "@types/node": "^14.0.0",
     "tapable": "^2.2.0"
   },
   "dependencies": {
-    "@octokit/core": "^3.4.0",
-    "@octokit/plugin-throttling": "^3.4.1"
-  },
-  "peerDependencies": {
     "@monodeploy/git": "^0.2.3",
     "@monodeploy/logging": "^0.1.5",
-    "@monodeploy/types": "^0.6.0"
+    "@monodeploy/types": "^0.6.0",
+    "@octokit/core": "^3.4.0",
+    "@octokit/plugin-throttling": "^3.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,7 +905,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/git@workspace:*, @monodeploy/git@workspace:^0.2.3, @monodeploy/git@workspace:packages/git":
+"@monodeploy/git@^0.2.3, @monodeploy/git@workspace:*, @monodeploy/git@workspace:^0.2.3, @monodeploy/git@workspace:packages/git":
   version: 0.0.0-use.local
   resolution: "@monodeploy/git@workspace:packages/git"
   dependencies:
@@ -939,7 +939,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monodeploy/logging@workspace:*, @monodeploy/logging@workspace:^0.1.5, @monodeploy/logging@workspace:packages/logging":
+"@monodeploy/logging@^0.1.5, @monodeploy/logging@workspace:*, @monodeploy/logging@workspace:^0.1.5, @monodeploy/logging@workspace:packages/logging":
   version: 0.0.0-use.local
   resolution: "@monodeploy/logging@workspace:packages/logging"
   dependencies:
@@ -1027,18 +1027,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@monodeploy/plugin-github@workspace:packages/plugin-github"
   dependencies:
-    "@monodeploy/git": "workspace:*"
-    "@monodeploy/logging": "workspace:*"
+    "@monodeploy/git": ^0.2.3
+    "@monodeploy/logging": ^0.1.5
     "@monodeploy/test-utils": "link:../../testUtils"
-    "@monodeploy/types": "workspace:*"
+    "@monodeploy/types": ^0.6.0
     "@octokit/core": ^3.4.0
     "@octokit/plugin-throttling": ^3.4.1
     "@types/node": ^14.0.0
     tapable: ^2.2.0
-  peerDependencies:
-    "@monodeploy/git": ^0.2.3
-    "@monodeploy/logging": ^0.1.5
-    "@monodeploy/types": ^0.6.0
   languageName: unknown
   linkType: soft
 
@@ -1132,7 +1128,7 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@monodeploy/types@workspace:*, @monodeploy/types@workspace:^0.6.0, @monodeploy/types@workspace:packages/types":
+"@monodeploy/types@^0.6.0, @monodeploy/types@workspace:*, @monodeploy/types@workspace:^0.6.0, @monodeploy/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@monodeploy/types@workspace:packages/types"
   dependencies:


### PR DESCRIPTION
Without this change, I receive:

```
TypeError: Cannot read property 'length' of undefined
    at computeLineStarts (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:9585:27)
    at Object.getLineStarts (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:9645:60)
    at getCurrentLineMap (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:101624:59)
    at emitDetachedCommentsAndUpdateCommentsInfo (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:105335:94)
    at emitBodyWithDetachedComments (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:105175:17)
    at emitSourceFile (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:103882:21)
    at pipelineEmitWithHint (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:101705:24)
    at noEmitNotification (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:100214:9)
    at onEmitNode (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:86096:13)
    at onEmitNode (/Users/noah/repos/monodeploy/.yarn/unplugged/typescript-patch-f44dec8005/node_modules/typescript/lib/typescript.js:96526:17)
Command failed: yarn run-local --dry-run --plugins @monodeploy/plugin-github
```

To reproduce the issue:

```
yarn run-local --dry-run --plugins @monodeploy/plugin-github
```

and the code where the plugin is imported is https://github.com/tophat/monodeploy/blob/1eb8d61cefdb2b9adef296e56acb888305edb11f/packages/node/src/index.ts#L74, however when I unplugged typescript and inspected what was actually failing, it was the import of `@monodeploy/git` inside of the @monodeploy/plugin-github package: https://github.com/tophat/monodeploy/blob/1eb8d61cefdb2b9adef296e56acb888305edb11f/packages/plugin-github/src/plugin.ts#L1