### PR TITLE
fix: refactor APIs to support non-latest dist tag

### DIFF
--- a/packages/changelog/src/writeChangesetFile.ts
+++ b/packages/changelog/src/writeChangesetFile.ts
@@ -6,7 +6,7 @@ import type {
     ChangesetSchema,
     MonodeployConfiguration,
     PackageStrategyMap,
-    PackageTagMap,
+    PackageVersionMap,
     YarnContext,
 } from '@monodeploy/types'
 
@@ -22,8 +22,8 @@ const writeChangesetFile = async ({
 }: {
     config: MonodeployConfiguration
     context: YarnContext
-    previousTags: PackageTagMap
-    nextTags: PackageTagMap
+    previousTags: PackageVersionMap
+    nextTags: PackageVersionMap
     versionStrategies: PackageStrategyMap
     createdGitTags?: Map<string, string>
 }): Promise<ChangesetSchema> => {

--- a/packages/io/src/patchPackageJsons.ts
+++ b/packages/io/src/patchPackageJsons.ts
@@ -1,6 +1,6 @@
 import type {
     MonodeployConfiguration,
-    PackageTagMap,
+    PackageVersionMap,
     YarnContext,
 } from '@monodeploy/types'
 import { Descriptor, Manifest, Workspace, structUtils } from '@yarnpkg/core'
@@ -10,7 +10,7 @@ const patchPackageJsons = async (
     config: MonodeployConfiguration,
     context: YarnContext,
     workspaces: Set<Workspace>,
-    registryTags: PackageTagMap,
+    registryTags: PackageVersionMap,
 ): Promise<void> => {
     const regenerateManifestRaw = async (
         workspace: Workspace,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -17,7 +17,7 @@ import type {
     ChangesetSchema,
     MonodeployConfiguration,
     PackageStrategyMap,
-    PackageTagMap,
+    PackageVersionMap,
     PluginHooks,
     RecursivePartial,
     YarnContext,
@@ -32,6 +32,7 @@ import { Configuration, Project, StreamReport, Workspace } from '@yarnpkg/core'
 import { npath } from '@yarnpkg/fslib'
 import { AsyncSeriesHook } from 'tapable'
 
+import { convertTagMapToVersions } from './utils/convert'
 import getCompatiblePluginConfiguration from './utils/getCompatiblePluginConfiguration'
 import {
     getFetchRegistryUrl,
@@ -166,7 +167,7 @@ const monodeploy = async (
                 },
             )
 
-            let newVersions: PackageTagMap
+            let newVersions: PackageVersionMap
 
             await report.startTimerPromise(
                 'Patching Package Manifests',
@@ -216,7 +217,9 @@ const monodeploy = async (
                     result = await writeChangesetFile({
                         config,
                         context,
-                        previousTags: registryTags, // old versions
+                        previousTags: convertTagMapToVersions(registryTags, {
+                            tag: 'latest',
+                        }), // old versions
                         nextTags: newVersions,
                         versionStrategies,
                         createdGitTags,

--- a/packages/node/src/utils/convert.ts
+++ b/packages/node/src/utils/convert.ts
@@ -1,0 +1,15 @@
+import { PackageTagMap, PackageVersionMap } from '@monodeploy/types'
+
+export const convertTagMapToVersions = (
+    tagMap: PackageTagMap,
+    { tag }: { tag: 'latest' | string },
+): PackageVersionMap => {
+    const versionMap: PackageVersionMap = new Map()
+    for (const [pkgName, map] of tagMap.entries()) {
+        const tagValue = map[tag]
+        if (tagValue) {
+            versionMap.set(pkgName, tagValue)
+        }
+    }
+    return versionMap
+}

--- a/packages/publish/src/createReleaseGitTags.ts
+++ b/packages/publish/src/createReleaseGitTags.ts
@@ -2,7 +2,7 @@ import { gitTag } from '@monodeploy/git'
 import logging from '@monodeploy/logging'
 import type {
     MonodeployConfiguration,
-    PackageTagMap,
+    PackageVersionMap,
     YarnContext,
 } from '@monodeploy/types'
 
@@ -13,7 +13,7 @@ async function createReleaseGitTags({
 }: {
     config: MonodeployConfiguration
     context: YarnContext
-    versions: PackageTagMap
+    versions: PackageVersionMap
 }): Promise<Map<string, string>> {
     const tags = await Promise.all(
         [...versions.entries()].map(async (packageVersionEntry: string[]) => {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -60,7 +60,12 @@ export type CommitMessage = {
     body: string
 }
 
-export type PackageTagMap = Map<string, string>
+export type PackageTagMap = Map<
+    string,
+    Record<string, string> & { latest: string }
+>
+
+export type PackageVersionMap = Map<string, string>
 
 export type PackageStrategyType = 'major' | 'minor' | 'patch'
 

--- a/packages/versions/src/applyReleases.test.ts
+++ b/packages/versions/src/applyReleases.test.ts
@@ -53,9 +53,9 @@ describe('applyReleases', () => {
                     context,
                     workspaces: new Set([workspace2, workspace3]),
                     registryTags: new Map([
-                        ['pkg-1', '1.0.0'],
-                        ['pkg-2', '2.0.0'],
-                        ['pkg-3', '3.3.0'],
+                        ['pkg-1', { latest: '1.0.0' }],
+                        ['pkg-2', { latest: '2.0.0' }],
+                        ['pkg-3', { latest: '3.3.0' }],
                     ]),
                     versionStrategies: new Map([
                         ['pkg-2', { type: 'minor', commits: [] }],

--- a/packages/versions/src/getLatestPackageTags.test.ts
+++ b/packages/versions/src/getLatestPackageTags.test.ts
@@ -64,20 +64,22 @@ describe('getLatestPackageTags', () => {
         })
         for (const tagPair of tags) {
             const tag = tagPair[1]
-            expect(tag).toEqual('0.0.0')
+            expect(tag.latest).toEqual('0.0.0')
         }
     })
 
     it('returns tags from the registry if they exist', async () => {
         const registryTags = new Map(
             Object.entries({
-                'pkg-1': '0.0.1',
-                'pkg-2': '0.1.0',
-                'pkg-3': '1.0.0',
+                'pkg-1': { latest: '0.0.1' },
+                'pkg-2': { latest: '0.1.0' },
+                'pkg-3': { latest: '1.0.0' },
             }),
         )
 
-        for (const tagPair of registryTags) mockNPM._setTag_(...tagPair)
+        for (const [pkgName, map] of registryTags) {
+            mockNPM._setTag_(pkgName, map.latest)
+        }
 
         const config = await getMonodeployConfig({
             cwd: context.project.cwd,
@@ -92,9 +94,9 @@ describe('getLatestPackageTags', () => {
 
         const expectedTags = new Map([
             ...registryTags.entries(),
-            ['pkg-4', '0.0.0'],
-            ['pkg-6', '0.0.0'],
-            ['pkg-7', '0.0.0'],
+            ['pkg-4', { latest: '0.0.0' }],
+            ['pkg-6', { latest: '0.0.0' }],
+            ['pkg-7', { latest: '0.0.0' }],
         ])
 
         expect(tags).toEqual(expectedTags)
@@ -149,7 +151,7 @@ describe('getLatestPackageTags', () => {
         })
         for (const tagPair of tags) {
             const tag = tagPair[1]
-            expect(tag).toEqual('0.0.0')
+            expect(tag.latest).toEqual('0.0.0')
         }
 
         mockNPM.npmHttpUtils.get = mockGet

--- a/packages/versions/src/getLatestPackageTags.ts
+++ b/packages/versions/src/getLatestPackageTags.ts
@@ -29,13 +29,15 @@ const getLatestPackageTags = async ({
                 !workspace?.manifest.private && workspace?.manifest.name,
         )
 
-    const fetchDistTag = async (workspace: Workspace) => {
+    const fetchDistTag = async (
+        workspace: Workspace,
+    ): Promise<[string, Record<string, string> & { latest: string }]> => {
         const ident = workspace.manifest.name!
         const pkgName = structUtils.stringifyIdent(ident)
         const manifestVersion = workspace.manifest.version ?? '0.0.0'
 
         if (config.noRegistry || !registryUrl) {
-            return [pkgName, manifestVersion]
+            return [pkgName, { latest: manifestVersion }]
         }
 
         const identUrl = pluginNPM.npmHttpUtils.getIdentUrl(ident)
@@ -50,7 +52,8 @@ const getLatestPackageTags = async ({
                     jsonResponse: true,
                 }),
             )
-            return [pkgName, result.latest]
+
+            return [pkgName, { latest: manifestVersion, ...result }]
         } catch (err) {
             const statusCode =
                 err.response?.statusCode ??
@@ -68,7 +71,7 @@ const getLatestPackageTags = async ({
                     `[Get Tags] Cannot find ${pkgName} in registry (version: ${manifestVersion}, ${config.registryUrl})`,
                     { report: context.report },
                 )
-                return [pkgName, manifestVersion]
+                return [pkgName, { latest: manifestVersion }]
             }
 
             if (
@@ -83,7 +86,7 @@ const getLatestPackageTags = async ({
                     `[Get Tags] [HTTP 500] Cannot find ${pkgName} in registry (version: ${manifestVersion})`,
                     { report: context.report },
                 )
-                return [pkgName, manifestVersion]
+                return [pkgName, { latest: manifestVersion }]
             }
 
             logging.error(


### PR DESCRIPTION
## Description

Refactors internal APIs to support accessing non-latest npm dist tags.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

This is a refactor in advance of pre-release support.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [ ] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
