### PR TITLE
feat: add prerelease config options

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -39,7 +39,7 @@ describe('CLI', () => {
                     '--push --persist-versions --access public --topological --topological-dev --jobs 6 ' +
                     '--auto-commit --auto-commit-message release --plugins plugin-a plugin-b ' +
                     '--max-concurrent-reads 3 --max-concurrent-writes 4 --no-git-tag ' +
-                    '--changeset-ignore-patterns "*.test.js"',
+                    '--changeset-ignore-patterns "*.test.js" --prerelease --prerelease-id rc',
             )
             jest.isolateModules(() => {
                 require('./cli')
@@ -78,6 +78,8 @@ describe('CLI', () => {
                     "plugin-a",
                     "plugin-b",
                   ],
+                  "prerelease": true,
+                  "prereleaseId": "rc",
                   "registryUrl": "http://example.com",
                   "topological": true,
                   "topologicalDev": true,
@@ -119,6 +121,8 @@ describe('CLI', () => {
                   "noRegistry": undefined,
                   "persistVersions": undefined,
                   "plugins": undefined,
+                  "prerelease": false,
+                  "prereleaseId": undefined,
                   "registryUrl": undefined,
                   "topological": undefined,
                   "topologicalDev": undefined,
@@ -244,6 +248,8 @@ describe('CLI', () => {
                     maxConcurrentReads: 3,
                     maxConcurrentWrites: 5,
                     plugins: ['plugin-a', 'plugin-b'],
+                    prerelease: true,
+                    prereleaseId: 'alpha',
                 }
             `
 
@@ -289,6 +295,8 @@ describe('CLI', () => {
                         "plugin-a",
                         "plugin-b",
                       ],
+                      "prerelease": false,
+                      "prereleaseId": "alpha",
                       "registryUrl": "http://example.com",
                       "topological": true,
                       "topologicalDev": true,
@@ -323,6 +331,7 @@ describe('CLI', () => {
                     topologicalDev: true,
                     maxConcurrentReads: 6,
                     maxConcurrentWrites: 2,
+                    prerelease: false,
                 }
             `
 
@@ -366,6 +375,8 @@ describe('CLI', () => {
                       "noRegistry": false,
                       "persistVersions": true,
                       "plugins": undefined,
+                      "prerelease": false,
+                      "prereleaseId": undefined,
                       "registryUrl": "http://example.com",
                       "topological": true,
                       "topologicalDev": true,
@@ -447,6 +458,8 @@ describe('CLI', () => {
                       "noRegistry": false,
                       "persistVersions": true,
                       "plugins": undefined,
+                      "prerelease": false,
+                      "prereleaseId": undefined,
                       "registryUrl": "http://example.com",
                       "topological": true,
                       "topologicalDev": true,
@@ -483,6 +496,8 @@ describe('CLI', () => {
                 topologicalDev: true,
                 maxConcurrentReads: 10,
                 maxConcurrentWrites: 11,
+                prerelease: true,
+                prereleaseId: 'beta',
             }
         `
 
@@ -527,6 +542,8 @@ describe('CLI', () => {
                       "noRegistry": false,
                       "persistVersions": true,
                       "plugins": undefined,
+                      "prerelease": false,
+                      "prereleaseId": "beta",
                       "registryUrl": "http://example.com",
                       "topological": true,
                       "topologicalDev": true,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -130,6 +130,15 @@ const { argv } = yargs
         description:
             'Globs to use in filtering out files when determining version bumps',
     })
+    .option('prerelease', {
+        type: 'boolean',
+        description: 'Whether to publish using a prerelease strategy',
+        default: false,
+    })
+    .option('prerelease-id', {
+        type: 'string',
+        description: 'The prerelease identifier when in prerelease mode.',
+    })
     .demandCommand(0, 0)
     .strict()
     .wrap(yargs.terminalWidth()) as { argv: ArgOutput }
@@ -218,6 +227,10 @@ if (argv.logLevel !== undefined && argv.logLevel !== null) {
                     ? argv.maxConcurrentWrites
                     : configFromFile?.maxConcurrentWrites) ?? 0,
             plugins: argv.plugins ?? configFromFile?.plugins ?? undefined,
+            prerelease:
+                argv.prerelease ?? configFromFile?.prerelease ?? undefined,
+            prereleaseId:
+                argv.prereleaseId ?? configFromFile?.prereleaseId ?? undefined,
         }
 
         await monodeploy(config)

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -27,6 +27,8 @@ export interface ArgOutput {
     maxConcurrentWrites?: number
     plugins?: Array<string>
     changesetIgnorePatterns?: Array<string>
+    prerelease?: boolean
+    prereleaseId?: string
 }
 
 export type ConfigFile = RecursivePartial<Omit<MonodeployConfiguration, 'cwd'>>

--- a/packages/cli/src/validateConfigFile.ts
+++ b/packages/cli/src/validateConfigFile.ts
@@ -42,6 +42,8 @@ const schema: JSONSchemaType<ConfigFile> = {
             nullable: true,
         },
         plugins: { type: 'array', nullable: true, items: { type: 'string' } },
+        prerelease: { type: 'boolean', nullable: true },
+        prereleaseId: { type: 'string', nullable: true },
     },
     required: [],
     additionalProperties: false,

--- a/packages/node/src/tests/dryRun.test.ts
+++ b/packages/node/src/tests/dryRun.test.ts
@@ -76,6 +76,8 @@ describe('Monodeploy (Dry Run)', () => {
         forceWriteChangeFiles: false,
         maxConcurrentReads: 2,
         maxConcurrentWrites: 0,
+        prerelease: false,
+        prereleaseId: 'rc',
     }
 
     beforeAll(async () => {

--- a/packages/node/src/tests/lifecycleScripts.test.ts
+++ b/packages/node/src/tests/lifecycleScripts.test.ts
@@ -50,6 +50,8 @@ describe('Monodeploy Lifecycle Scripts', () => {
         forceWriteChangeFiles: false,
         maxConcurrentReads: 4,
         maxConcurrentWrites: 3,
+        prerelease: false,
+        prereleaseId: 'rc',
     }
 
     const resolvePackagePath = (pkgName: string, filename: string) =>

--- a/packages/node/src/tests/main.test.ts
+++ b/packages/node/src/tests/main.test.ts
@@ -97,6 +97,8 @@ describe('Monodeploy', () => {
         forceWriteChangeFiles: false,
         maxConcurrentReads: 2,
         maxConcurrentWrites: 2,
+        prerelease: false,
+        prereleaseId: 'rc',
     }
 
     beforeAll(async () => {

--- a/packages/node/src/tests/plugins.test.ts
+++ b/packages/node/src/tests/plugins.test.ts
@@ -88,6 +88,8 @@ describe('Monodeploy Plugins', () => {
         forceWriteChangeFiles: false,
         maxConcurrentReads: 2,
         maxConcurrentWrites: 2,
+        prerelease: false,
+        prereleaseId: 'rc',
     }
 
     beforeAll(async () => {

--- a/packages/node/src/utils/mergeDefaultConfig.test.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.test.ts
@@ -76,6 +76,8 @@ describe('Config Merging', () => {
             maxConcurrentReads: 3,
             maxConcurrentWrites: 2,
             plugins: [],
+            prerelease: true,
+            prereleaseId: 'rc',
         }
 
         const merged = await mergeDefaultConfig(config)

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -42,6 +42,8 @@ const mergeDefaultConfig = async (
         maxConcurrentReads: baseConfig.maxConcurrentReads ?? 0,
         maxConcurrentWrites: baseConfig.maxConcurrentWrites ?? 0,
         plugins: baseConfig.plugins ?? [],
+        prerelease: baseConfig.prerelease ?? false,
+        prereleaseId: baseConfig.prereleaseId ?? 'rc',
     }
 }
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -34,6 +34,8 @@ export interface MonodeployConfiguration {
     maxConcurrentReads: number
     maxConcurrentWrites: number
     plugins?: Array<string>
+    prerelease: boolean
+    prereleaseId?: string
 }
 
 export interface YarnContext {

--- a/packages/versions/src/versionStrategy.test.ts
+++ b/packages/versions/src/versionStrategy.test.ts
@@ -88,6 +88,8 @@ describe('Custom Conventional Recommended Strategy', () => {
         jobs: 0,
         maxConcurrentReads: 1,
         maxConcurrentWrites: 1,
+        prerelease: false,
+        prereleaseId: 'rc',
     }
 
     afterEach(() => {


### PR DESCRIPTION
## Description

Adds `prerelease` and `prereleaseId` config options. This does not add the actual prerelease implementation, just the options.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [ ] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
