### PR TITLE
feat(git): support pre-release mode

### DIFF
--- a/__mocks__/@monodeploy/git.ts
+++ b/__mocks__/@monodeploy/git.ts
@@ -148,9 +148,11 @@ export const gitCommit = async (
 const gitLastTaggedCommit = async ({
     cwd,
     context,
+    prerelease = false,
 }: {
     cwd: string
     context: YarnContext
+    prerelease?: boolean
 }): Promise<string> => {
     if (!registry.lastTaggedCommit) {
         throw new Error('No tagged commit.')

--- a/e2e-tests/helpers/setupProject.ts
+++ b/e2e-tests/helpers/setupProject.ts
@@ -78,12 +78,9 @@ export default function setupProject({
             await exec('git pull --rebase --no-verify origin master', {
                 cwd: project,
             })
-            await exec(
-                'git add . && git commit -n -m "initial commit" && git tag initial -m initial',
-                {
-                    cwd: project,
-                },
-            )
+            await exec('git add . && git commit -n -m "initial commit"', {
+                cwd: project,
+            })
             await exec(`git push -u origin master`, {
                 cwd: project,
             })

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -128,7 +128,7 @@ export const gitLastTaggedCommit = async ({
     context?: YarnContext
     prerelease?: boolean
 }): Promise<string> => {
-    let mostRecentTagCommand = `git describe --abbrev=0`
+    let mostRecentTagCommand = `git describe --abbrev=0 --match '*@*[[:digit:]]*.[[:digit:]]*.[[:digit:]]*'`
 
     if (!prerelease) {
         // The glob matches prerelease ranges. The 'complexity' comes from not wanting

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -122,14 +122,21 @@ export const gitPush = async ({
 export const gitLastTaggedCommit = async ({
     cwd,
     context,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     prerelease = false,
 }: {
     cwd: string
     context?: YarnContext
     prerelease?: boolean
 }): Promise<string> => {
-    const mostRecentTagCommand = `git describe --abbrev=0`
+    let mostRecentTagCommand = `git describe --abbrev=0`
+
+    if (!prerelease) {
+        // The glob matches prerelease ranges. The 'complexity' comes from not wanting
+        // to be overeager in producing a false positive for a tag such as
+        // `@scope-with-hyphen/name.with.dot-and-hyphen`
+        mostRecentTagCommand = `${mostRecentTagCommand} --exclude '*@*[[:digit:]]*.[[:digit:]]*.[[:digit:]]*-*'`
+    }
+
     logging.debug(`[Exec] ${mostRecentTagCommand}`, { report: context?.report })
 
     let tag = 'HEAD'

--- a/packages/git/src/index.mocked.test.ts
+++ b/packages/git/src/index.mocked.test.ts
@@ -44,7 +44,7 @@ describe('@monodeploy/git (mocked invariants)', () => {
         execSync('git commit -m "test: base" --allow-empty', {
             cwd,
         })
-        const newTag = '1.0.0'
+        const newTag = 'pkg@1.0.0'
         await gitTag(newTag, { cwd, context })
         const tagList = execSync('git tag -l', {
             cwd,
@@ -59,7 +59,7 @@ describe('@monodeploy/git (mocked invariants)', () => {
         execSync('git commit -m "test: base" --allow-empty', {
             cwd,
         })
-        const tag = '1.0.0'
+        const tag = 'pkg@1.0.0'
         await gitTag(tag, { cwd, context })
         const lastTaggedSha = await gitLastTaggedCommit({ cwd, context })
         const actualSha = execSync(`git log ${tag} -1 --pretty=%H`, {
@@ -79,7 +79,7 @@ describe('@monodeploy/git (mocked invariants)', () => {
             cwd,
         })
 
-        await gitTag('1.0.0', { cwd, context })
+        await gitTag('pkg@1.0.0', { cwd, context })
         await gitPushTags({ cwd, remote: 'local', context })
 
         const lastTaggedSha = await gitLastTaggedCommit({ cwd, context })

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -1,4 +1,7 @@
-import { execSync } from 'child_process'
+import childProcess from 'child_process'
+import util from 'util'
+
+const exec = util.promisify(childProcess.exec)
 
 import {
     cleanUp,
@@ -15,6 +18,7 @@ import {
     gitCommit,
     gitDiffTree,
     gitLastTaggedCommit,
+    gitLog,
     gitPushTags,
     gitResolveSha,
     gitTag,
@@ -22,8 +26,10 @@ import {
 
 describe('@monodeploy/git', () => {
     let context: YarnContext
+    let prevNodeEnv: string | undefined
 
     beforeEach(async () => {
+        prevNodeEnv = process.env.NODE_ENV
         context = await setupMonorepo({
             'pkg-1': {},
             'pkg-2': {},
@@ -36,156 +42,278 @@ describe('@monodeploy/git', () => {
             'pkg-7': {},
         })
         const rootPath = context.project.cwd
-        await initGitRepository(rootPath)
+        await initGitRepository(rootPath, { allowScaffoldingCommits: false })
     })
 
     afterEach(async () => {
+        process.env.NODE_ENV = prevNodeEnv
         jest.restoreAllMocks()
         await cleanUp([context.project.cwd])
     })
 
-    it('gitDiffTree returns list of modified files', async () => {
-        const cwd = context.project.cwd
+    describe('gitDiffTree', () => {
+        it('returns list of modified files', async () => {
+            const cwd = context.project.cwd
 
-        await createFile({ filePath: 'test.txt', cwd })
-        await createFile({ filePath: 'testDir/test.txt', cwd })
+            await createFile({ filePath: 'test.txt', cwd })
+            await createFile({ filePath: 'testDir/test.txt', cwd })
 
-        execSync('git add . && git commit -m "test: test file" -n', {
-            cwd,
-        })
-        const headSha = execSync('git rev-parse HEAD', {
-            cwd,
-            encoding: 'utf8',
-        })
-
-        const diffTreeOutput = await gitDiffTree(headSha, { cwd, context })
-
-        expect(diffTreeOutput.trim()).toEqual(
-            expect.stringContaining(
-                ['test.txt', 'testDir/test.txt'].join('\n'),
-            ),
-        )
-    })
-
-    it('gitResolveSha resolves HEAD properly', async () => {
-        const cwd = context.project.cwd
-
-        await createFile({ filePath: 'test.txt', cwd })
-        execSync('git add . && git commit -m "test: test file" -n', {
-            cwd,
-        })
-        const headSha = execSync('git rev-parse HEAD', {
-            cwd,
-            encoding: 'utf8',
-        })
-
-        const resolvedHead = await gitResolveSha('HEAD', { cwd, context })
-
-        expect(resolvedHead).toEqual(headSha.trim())
-    })
-
-    it('getCommitMessages gets commit messages', async () => {
-        const cwd = context.project.cwd
-
-        // Create some files and commit them to have a diff.
-        await createFile({ filePath: 'test.txt', cwd })
-        execSync('git commit -m "test: base" --allow-empty', {
-            cwd,
-        })
-        execSync('git checkout -b test-branch', { cwd, stdio: 'ignore' })
-        const commitMessage = 'test: test file'
-        execSync(`git add . && git commit -m "${commitMessage}" -n`, {
-            cwd,
-        })
-        const headSha = execSync('git rev-parse HEAD', {
-            cwd,
-            encoding: 'utf8',
-        }).trim()
-
-        const messages = await getCommitMessages(
-            await getMonodeployConfig({
+            await exec('git add . && git commit -m "test: test file" -n', {
                 cwd,
-                baseBranch: 'master',
-                commitSha: headSha,
-            }),
-            context,
-        )
+            })
+            const { stdout: headSha } = await exec('git rev-parse HEAD', {
+                cwd,
+                encoding: 'utf8',
+            })
 
-        expect(messages).toEqual([
-            { sha: headSha, body: `${commitMessage}\n\n` },
-        ])
+            const diffTreeOutput = await gitDiffTree(headSha, { cwd, context })
+
+            expect(diffTreeOutput.trim()).toEqual(
+                expect.stringContaining(
+                    ['test.txt', 'testDir/test.txt'].join('\n'),
+                ),
+            )
+        })
     })
 
-    it('gitTag fails if invariant not respected', async () => {
-        const cwd = context.project.cwd
-        execSync('git commit -m "test: base" --allow-empty', {
-            cwd,
+    describe('gitResolveSha', () => {
+        it('resolves HEAD properly', async () => {
+            const cwd = context.project.cwd
+
+            await createFile({ filePath: 'test.txt', cwd })
+            await exec('git add . && git commit -m "test: test file" -n', {
+                cwd,
+            })
+            const { stdout: headSha } = await exec('git rev-parse HEAD', {
+                cwd,
+                encoding: 'utf8',
+            })
+
+            const resolvedHead = await gitResolveSha('HEAD', { cwd, context })
+
+            expect(resolvedHead).toEqual(headSha.trim())
         })
-        await expect(async () =>
-            gitTag('1.0.0', { cwd, context }),
-        ).rejects.toMatchInlineSnapshot(
-            `[Error: Invariant Violation: Invalid environment test !== production.]`,
-        )
     })
 
-    it('gitPushTags fails if invariant not respected', async () => {
-        const cwd = context.project.cwd
-        execSync('git commit -m "test: base" --allow-empty', {
-            cwd,
+    describe('gitCommitMessages', () => {
+        it('gets commit messages', async () => {
+            const cwd = context.project.cwd
+
+            // Create some files and commit them to have a diff.
+            await createFile({ filePath: 'test.txt', cwd })
+            await exec('git commit -m "test: base" --allow-empty', {
+                cwd,
+            })
+            await exec('git checkout -b test-branch', { cwd })
+            const commitMessage = 'test: test file'
+            await exec(`git add . && git commit -m "${commitMessage}" -n`, {
+                cwd,
+            })
+            const headSha = (
+                await exec('git rev-parse HEAD', {
+                    cwd,
+                    encoding: 'utf8',
+                })
+            ).stdout.trim()
+
+            const messages = await getCommitMessages(
+                await getMonodeployConfig({
+                    cwd,
+                    baseBranch: 'master',
+                    commitSha: headSha,
+                }),
+                context,
+            )
+
+            expect(messages).toEqual([
+                { sha: headSha, body: `${commitMessage}\n\n` },
+            ])
         })
-        await expect(async () =>
-            gitPushTags({ cwd, context, remote: 'origin' }),
-        ).rejects.toMatchInlineSnapshot(
-            `[Error: Invariant Violation: Invalid environment test !== production.]`,
-        )
+    })
+
+    describe('gitTag', () => {
+        it('fails if invariant not respected', async () => {
+            const cwd = context.project.cwd
+            await exec('git commit -m "test: base" --allow-empty', {
+                cwd,
+            })
+            await expect(async () =>
+                gitTag('1.0.0', { cwd, context }),
+            ).rejects.toMatchInlineSnapshot(
+                `[Error: Invariant Violation: Invalid environment test !== production.]`,
+            )
+        })
+
+        it('creates an annotated tag', async () => {
+            process.env.NODE_ENV = 'production'
+
+            const { cwd } = context.project
+
+            await exec('git commit -m "test: base" --allow-empty', {
+                cwd,
+            })
+
+            await gitTag('1.0.0', { cwd, context })
+
+            const { stdout } = await exec('git describe --abbrev=0', { cwd })
+            expect(stdout).toEqual(expect.stringContaining('1.0.0'))
+        })
+    })
+
+    describe('gitPushTags', () => {
+        it('fails if invariant not respected', async () => {
+            const cwd = context.project.cwd
+            await exec('git commit -m "test: base" --allow-empty', {
+                cwd,
+            })
+            await expect(async () =>
+                gitPushTags({ cwd, context, remote: 'origin' }),
+            ).rejects.toMatchInlineSnapshot(
+                `[Error: Invariant Violation: Invalid environment test !== production.]`,
+            )
+        })
     })
 
     describe('gitLastTaggedCommit', () => {
-        it('defaults to HEAD^ if no tag exists', async () => {
+        it('defaults to HEAD if no tag exists', async () => {
             const cwd = context.project.cwd
             await createFile({ filePath: 'test.txt', cwd })
-            execSync('git add . && git commit -m "chore: initial commit" -n', {
-                cwd,
-            })
+            await exec(
+                'git add . && git commit -m "chore: initial commit" -n',
+                {
+                    cwd,
+                },
+            )
 
             await createFile({ filePath: 'test1.txt', cwd })
-            execSync('git add . && git commit -m "chore: second commit" -n', {
+            await exec('git add . && git commit -m "chore: second commit" -n', {
                 cwd,
             })
 
-            const headSha = await gitResolveSha('HEAD^', { cwd, context })
+            const headSha = await gitResolveSha('HEAD', { cwd, context })
+            const commit = await gitLastTaggedCommit({ cwd, context })
+            expect(commit).toEqual(headSha)
+        })
+
+        it('defaults to HEAD if on initial commit', async () => {
+            const cwd = context.project.cwd
+            await createFile({ filePath: 'test.txt', cwd })
+            await exec(
+                'git add . && git commit -m "chore: initial commit" -n',
+                {
+                    cwd,
+                },
+            )
+            const headSha = await gitResolveSha('HEAD', { cwd, context })
             const commit = await gitLastTaggedCommit({ cwd, context })
             expect(commit).toEqual(headSha)
         })
 
         it('gets the last tagged commit', async () => {
-            const prevNodeEnv = process.env.NODE_ENV
             process.env.NODE_ENV = 'production'
 
             const cwd = context.project.cwd
             await createFile({ filePath: 'test.txt', cwd })
-            execSync('git add . && git commit -m "chore: initial commit" -n', {
-                cwd,
-            })
+            await exec(
+                'git add . && git commit -m "chore: initial commit" -n',
+                {
+                    cwd,
+                },
+            )
             const taggedSha = await gitResolveSha('HEAD', { cwd, context })
             await gitTag('test-tag', { cwd, context })
 
             await createFile({ filePath: 'test2.txt', cwd })
-            execSync('git add . && git commit -m "chore: non-tagged" -n', {
+            await exec('git add . && git commit -m "chore: non-tagged" -n', {
                 cwd,
             })
 
             expect(await gitLastTaggedCommit({ cwd, context })).toEqual(
                 taggedSha,
             )
+        })
 
-            process.env.NODE_ENV = prevNodeEnv
+        it.todo('skips prerelease tags if not in prerelease mode')
+    })
+
+    describe('gitLog', () => {
+        it('returns an entry for commit between from and to refs', async () => {
+            process.env.NODE_ENV = 'production'
+
+            const DELIMITER = '===='
+
+            const cwd = context.project.cwd
+
+            await createFile({ filePath: 'other.txt', cwd })
+            await exec(
+                'git add . && git commit -m "chore: initial commit" -n',
+                {
+                    cwd,
+                },
+            )
+            const fromSha = await gitResolveSha('HEAD', { cwd, context })
+
+            await createFile({ filePath: 'test.txt', cwd })
+            await exec('git add . && git commit -m "chore: second commit" -n', {
+                cwd,
+            })
+
+            await createFile({ filePath: 'test1.txt', cwd })
+            await exec('git add . && git commit -m "chore: third commit" -n', {
+                cwd,
+            })
+            const toSha = await gitResolveSha('HEAD', { cwd, context })
+
+            // Note that gitLog excludes the "from" commit itself
+            const logEntries = (
+                await gitLog(fromSha, toSha, { cwd, DELIMITER })
+            )
+                .split(DELIMITER)
+                .filter((v) => Boolean(v.trim()))
+
+            expect(logEntries).toHaveLength(2)
+            expect(logEntries).toEqual(
+                expect.arrayContaining([
+                    expect.stringContaining('chore: third commit'),
+                    expect.stringContaining('chore: second commit'),
+                ]),
+            )
+        })
+
+        it('returns a single commit entry if "from" ref is the same as "to" ref', async () => {
+            process.env.NODE_ENV = 'production'
+
+            const DELIMITER = '===='
+
+            const cwd = context.project.cwd
+
+            await createFile({ filePath: 'other.txt', cwd })
+            await exec(
+                'git add . && git commit -m "chore: initial commit" -n',
+                {
+                    cwd,
+                },
+            )
+
+            await createFile({ filePath: 'test.txt', cwd })
+            await exec('git add . && git commit -m "chore: second commit" -n', {
+                cwd,
+            })
+            const sha = await gitResolveSha('HEAD', { cwd, context })
+
+            const logEntries = (await gitLog(sha, sha, { cwd, DELIMITER }))
+                .split(DELIMITER)
+                .filter((v) => Boolean(v.trim()))
+
+            expect(logEntries).toHaveLength(1)
+            expect(logEntries[0]).toEqual(
+                expect.stringContaining('chore: second commit'),
+            )
         })
     })
 
     describe('gitAdd, gitCommit', () => {
         it('adds files, commits changes', async () => {
-            const prevNodeEnv = process.env.NODE_ENV
             process.env.NODE_ENV = 'production'
 
             const cwd = context.project.cwd
@@ -194,23 +322,25 @@ describe('@monodeploy/git', () => {
 
             // assert added
             expect(
-                execSync('git ls-files --error-unmatch test.txt', {
-                    encoding: 'utf8',
-                    cwd,
-                }).toString(),
+                (
+                    await exec('git ls-files --error-unmatch test.txt', {
+                        encoding: 'utf8',
+                        cwd,
+                    })
+                ).stdout.toString(),
             ).toEqual(expect.stringContaining('test.txt'))
 
             await gitCommit('chore: initial commit', { cwd, context })
 
             // assert committed
             expect(
-                execSync('git log -1 --format="%B"', {
-                    encoding: 'utf8',
-                    cwd,
-                }).toString(),
+                (
+                    await exec('git log -1 --format="%B"', {
+                        encoding: 'utf8',
+                        cwd,
+                    })
+                ).stdout.toString(),
             ).toEqual(expect.stringContaining('chore: initial commit'))
-
-            process.env.NODE_ENV = prevNodeEnv
         })
     })
 })

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -138,7 +138,7 @@ describe('@monodeploy/git', () => {
                 cwd,
             })
             await expect(async () =>
-                gitTag('1.0.0', { cwd, context }),
+                gitTag('pkg@1.0.0', { cwd, context }),
             ).rejects.toMatchInlineSnapshot(
                 `[Error: Invariant Violation: Invalid environment test !== production.]`,
             )
@@ -153,7 +153,7 @@ describe('@monodeploy/git', () => {
                 cwd,
             })
 
-            await gitTag('1.0.0', { cwd, context })
+            await gitTag('pkg@1.0.0', { cwd, context })
 
             const { stdout } = await exec('git describe --abbrev=0', { cwd })
             expect(stdout).toEqual(expect.stringContaining('1.0.0'))
@@ -221,7 +221,7 @@ describe('@monodeploy/git', () => {
                 },
             )
             const taggedSha = await gitResolveSha('HEAD', { cwd, context })
-            await gitTag('test-tag', { cwd, context })
+            await gitTag('test-tag@0.0.1', { cwd, context })
 
             await createFile({ filePath: 'test2.txt', cwd })
             await exec('git add . && git commit -m "chore: non-tagged" -n', {

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -8,6 +8,7 @@ const mergeDefaultConfig = async (
     baseConfig: RecursivePartial<MonodeployConfiguration>,
 ): Promise<MonodeployConfiguration> => {
     const cwd = baseConfig.cwd ?? process.cwd()
+    const prerelease = baseConfig.prerelease ?? false
 
     return {
         registryUrl: baseConfig.registryUrl ?? undefined,
@@ -17,7 +18,7 @@ const mergeDefaultConfig = async (
         git: {
             baseBranch:
                 baseConfig.git?.baseBranch ??
-                (await gitLastTaggedCommit({ cwd })),
+                (await gitLastTaggedCommit({ cwd, prerelease })),
             commitSha:
                 baseConfig.git?.commitSha ??
                 (await gitResolveSha('HEAD', { cwd })),
@@ -42,7 +43,7 @@ const mergeDefaultConfig = async (
         maxConcurrentReads: baseConfig.maxConcurrentReads ?? 0,
         maxConcurrentWrites: baseConfig.maxConcurrentWrites ?? 0,
         plugins: baseConfig.plugins ?? [],
-        prerelease: baseConfig.prerelease ?? false,
+        prerelease,
         prereleaseId: baseConfig.prereleaseId ?? 'rc',
     }
 }

--- a/testUtils/git.ts
+++ b/testUtils/git.ts
@@ -6,7 +6,12 @@ import { YarnContext } from '@monodeploy/types'
 
 import setupMonorepo from './setupMonorepo'
 
-export async function initGitRepository(cwd: string): Promise<void> {
+export async function initGitRepository(
+    cwd: string,
+    {
+        allowScaffoldingCommits = true,
+    }: { allowScaffoldingCommits?: boolean } = {},
+): Promise<void> {
     execSync('git init', { cwd })
     // This is needed to disable signing if set up by the host.
     execSync('echo "[commit]\ngpgSign=false" > .git/config', { cwd })
@@ -18,7 +23,9 @@ export async function initGitRepository(cwd: string): Promise<void> {
             encoding: 'utf8',
         },
     )
-    execSync(`git add .gitignore && git commit -n -m "gitignore"`, { cwd })
+    if (allowScaffoldingCommits) {
+        execSync(`git add .gitignore && git commit -n -m "gitignore"`, { cwd })
+    }
 }
 
 export async function addGitRemote(


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Makes `@monodeploy/git` aware of pre-release mode. Mainly, to exclude prerelease tags in determining the base commit outside of pre-release mode.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #351, as I was refactoring the git commands anyway.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [ ] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
