### PR TITLE
fix: consider `prerelease` flag from config file

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -232,7 +232,7 @@ if (argv.logLevel !== undefined && argv.logLevel !== null) {
                     : configFromFile?.maxConcurrentWrites) ?? 0,
             plugins: argv.plugins ?? configFromFile?.plugins ?? undefined,
             prerelease:
-                argv.prerelease ?? configFromFile?.prerelease ?? undefined,
+                (argv.prerelease || configFromFile?.prerelease) ?? undefined,
             prereleaseId:
                 argv.prereleaseId ?? configFromFile?.prereleaseId ?? undefined,
             prereleaseNPMTag:


### PR DESCRIPTION
I have noticed that the `prerelease: true` in my `monodeploy.config.js` is getting ignored. This was caused due to the fact that `argv.prerelease` has a default value `false`.

This is small change to support reading `prerelease` from the config file. It's handled in the same way as `autoCommit` flag.