### PR TITLE
fix: do not modify any files in dry run mode

### DIFF
--- a/packages/io/src/patchPackageJsons.ts
+++ b/packages/io/src/patchPackageJsons.ts
@@ -108,9 +108,11 @@ const patchPackageJsons = async (
             workspace.manifest.indent,
         )}\n`
 
-        await xfs.changeFilePromise(path, content, {
-            automaticNewlines: true,
-        })
+        if (!config.dryRun) {
+            await xfs.changeFilePromise(path, content, {
+                automaticNewlines: true,
+            })
+        }
     }
 
     await Promise.all([...workspaces].map(patchWorkspace))

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -148,10 +148,17 @@ const monodeploy = async (
         }
 
         // Backup workspace package.jsons
-        const backupKey = await backupPackageJsons({ config, context })
-        logging.debug(`[Savepoint] Saving working tree (key: ${backupKey})`, {
-            report,
-        })
+        let backupKey: string | undefined
+
+        if (!config.dryRun) {
+            backupKey = await backupPackageJsons({ config, context })
+            logging.debug(
+                `[Savepoint] Saving working tree (key: ${backupKey})`,
+                {
+                    report,
+                },
+            )
+        }
 
         try {
             let workspacesToPublish: Set<Workspace>
@@ -264,6 +271,10 @@ const monodeploy = async (
                 'Cleaning Up',
                 { skipIfEmpty: false },
                 async () => {
+                    // Nothing to clean up in dry run mode
+                    // (marked by backup key never being created)
+                    if (!backupKey) return
+
                     if (!config.persistVersions) {
                         // Restore workspace package.jsons
                         logging.debug(

--- a/packages/publish/src/index.ts
+++ b/packages/publish/src/index.ts
@@ -83,9 +83,19 @@ export const publishPackages = async ({
             }
         }
 
-        await prepareForPublish(context, workspace, { cwd }, async () => {
-            await prepareForPack(context, workspace, { cwd }, pack)
-        })
+        await prepareForPublish(
+            context,
+            workspace,
+            { cwd, dryRun: config.dryRun },
+            async () => {
+                await prepareForPack(
+                    context,
+                    workspace,
+                    { cwd, dryRun: config.dryRun },
+                    pack,
+                )
+            },
+        )
     }
 
     const limit = pLimit(config.jobs || Infinity)

--- a/packages/publish/src/prepare.ts
+++ b/packages/publish/src/prepare.ts
@@ -6,11 +6,12 @@ import { PortablePath } from '@yarnpkg/fslib'
 export const prepareForPack = async (
     context: YarnContext,
     workspace: Workspace,
-    { cwd }: { cwd: PortablePath },
+    { cwd, dryRun }: { cwd: PortablePath; dryRun: boolean },
     cb: () => Promise<void>,
 ): Promise<void> => {
     await maybeExecuteWorkspaceLifecycleScript(context, workspace, 'prepack', {
         cwd,
+        dryRun,
     })
     try {
         await cb()
@@ -21,6 +22,7 @@ export const prepareForPack = async (
             'postpack',
             {
                 cwd,
+                dryRun,
             },
         )
     }
@@ -29,7 +31,7 @@ export const prepareForPack = async (
 export const prepareForPublish = async (
     context: YarnContext,
     workspace: Workspace,
-    { cwd }: { cwd: PortablePath },
+    { cwd, dryRun }: { cwd: PortablePath; dryRun: boolean },
     cb: () => Promise<void>,
 ): Promise<void> => {
     await maybeExecuteWorkspaceLifecycleScript(
@@ -38,11 +40,13 @@ export const prepareForPublish = async (
         'prepublishOnly',
         {
             cwd,
+            dryRun,
         },
     )
 
     await maybeExecuteWorkspaceLifecycleScript(context, workspace, 'prepare', {
         cwd,
+        dryRun,
     })
 
     await maybeExecuteWorkspaceLifecycleScript(
@@ -51,6 +55,7 @@ export const prepareForPublish = async (
         'prepublish',
         {
             cwd,
+            dryRun,
         },
     )
 
@@ -63,6 +68,7 @@ export const prepareForPublish = async (
             'postpublish',
             {
                 cwd,
+                dryRun,
             },
         )
     }


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Do not modify filesystem in dry run mode. Since lifecycle scripts can have arbitrary side-effects, we'll also disable them in dry run.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #390

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
