### PR TITLE
fix: add 'infer' access option to provide backwards compatibility

### DIFF
--- a/gatsby/src/pages-md/configuration.md
+++ b/gatsby/src/pages-md/configuration.md
@@ -53,7 +53,15 @@ export interface MonodeployConfiguration {
     changelogFilename?: string
     changesetIgnorePatterns?: Array<string>
     forceWriteChangeFiles: boolean
-    access: string
+
+    /**
+     * Name: access
+     * Default: public
+     *
+     * This overrides the access defined in the publishConfig of individual
+     * workspaces. Set this to 'infer' to respect individual workspace configurations.
+     */
+    access?: 'infer' | 'public' | 'restricted'
     persistVersions: boolean
     autoCommit: boolean
     autoCommitMessage: string

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -36,7 +36,7 @@ describe('CLI', () => {
                     '--git-base-branch main --git-commit-sha HEAD --git-remote origin ' +
                     '--log-level 0 --conventional-changelog-config @my/config ' +
                     '--changeset-filename changes.json --prepend-changelog changelog.md --force-write-change-files ' +
-                    '--push --persist-versions --access public --topological --topological-dev --jobs 6 ' +
+                    '--push --persist-versions --access infer --topological --topological-dev --jobs 6 ' +
                     '--auto-commit --auto-commit-message release --plugins plugin-a plugin-b ' +
                     '--max-concurrent-reads 3 --max-concurrent-writes 4 --no-git-tag ' +
                     '--changeset-ignore-patterns "*.test.js" --prerelease --prerelease-id rc --prerelease-npm-tag beta',
@@ -50,7 +50,7 @@ describe('CLI', () => {
                     .calls[0][0],
             ).toMatchInlineSnapshot(`
                 Object {
-                  "access": "public",
+                  "access": "infer",
                   "autoCommit": true,
                   "autoCommitMessage": "release",
                   "changelogFilename": "changelog.md",
@@ -314,7 +314,7 @@ describe('CLI', () => {
         it('reads from specified config file using path relative to cwd', async () => {
             const configFileContents = `
                 module.exports = {
-                    access: 'public',
+                    access: 'restricted',
                     changelogFilename: 'from_file.changelog.md',
                     changesetFilename: 'from_file.changes.json',
                     conventionalChangelogConfig: {
@@ -360,7 +360,7 @@ describe('CLI', () => {
                 expect({ ...config, cwd: config.cwd ? '/tmp/cwd' : null })
                     .toMatchInlineSnapshot(`
                     Object {
-                      "access": "public",
+                      "access": "restricted",
                       "autoCommit": undefined,
                       "autoCommitMessage": undefined,
                       "changelogFilename": "from_file.changelog.md",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -79,6 +79,7 @@ const { argv } = yargs
         type: 'string',
         description:
             'Whether the package should be deployed as public or restricted (only applies to scoped packages)',
+        choices: ['infer', 'public', 'restricted'],
     })
     .option('auto-commit', {
         type: 'boolean',

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -17,7 +17,7 @@ export interface ArgOutput {
     changesetFilename?: string
     forceWriteChangeFiles?: boolean
     prependChangelog?: string
-    access?: string
+    access?: 'infer' | 'public' | 'restricted'
     push?: boolean
     persistVersions?: boolean
     topological?: boolean

--- a/packages/cli/src/validateConfigFile.ts
+++ b/packages/cli/src/validateConfigFile.ts
@@ -31,7 +31,11 @@ const schema: SchemaObject = {
             items: { type: 'string' },
         },
         forceWriteChangeFiles: { type: 'boolean', nullable: true },
-        access: { type: 'string', nullable: true },
+        access: {
+            type: 'string',
+            nullable: true,
+            enum: ['infer', 'public', 'restricted'],
+        },
         persistVersions: { type: 'boolean', nullable: true },
         topological: { type: 'boolean', nullable: true },
         topologicalDev: { type: 'boolean', nullable: true },

--- a/packages/node/src/tests/main.test.ts
+++ b/packages/node/src/tests/main.test.ts
@@ -123,6 +123,51 @@ describe('Monodeploy', () => {
         delete process.env.MONODEPLOY_LOG_LEVEL
     })
 
+    it('passes correct access when publishing by default', async () => {
+        const spyPublish = jest.spyOn(npm.npmPublishUtils, 'makePublishBody')
+
+        mockNPM._setTag_('pkg-1', '0.0.1')
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', [
+            './packages/pkg-1/README.md',
+        ])
+
+        await monodeploy({
+            ...monodeployConfig,
+            access: undefined,
+        })
+
+        expect(spyPublish.mock.calls[0][2]).toEqual(
+            expect.objectContaining({
+                access: 'public',
+            }),
+        )
+        spyPublish.mockClear()
+
+        await monodeploy({
+            ...monodeployConfig,
+            access: 'restricted',
+        })
+
+        expect(spyPublish.mock.calls[0][2]).toEqual(
+            expect.objectContaining({
+                access: 'restricted',
+            }),
+        )
+        spyPublish.mockClear()
+
+        await monodeploy({
+            ...monodeployConfig,
+            access: 'infer',
+        })
+
+        expect(spyPublish.mock.calls[0][2]).toEqual(
+            expect.objectContaining({
+                access: undefined,
+            }),
+        )
+        spyPublish.mockClear()
+    })
+
     it('logs an error if publishing fails', async () => {
         const spyPublish = jest
             .spyOn(npm.npmHttpUtils, 'put')

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -32,7 +32,7 @@ const mergeDefaultConfig = async (
         changelogFilename: baseConfig.changelogFilename ?? undefined,
         changesetIgnorePatterns: baseConfig.changesetIgnorePatterns ?? [],
         forceWriteChangeFiles: baseConfig.forceWriteChangeFiles ?? false,
-        access: baseConfig.access ?? undefined,
+        access: baseConfig.access ?? 'public',
         persistVersions: baseConfig.persistVersions ?? false,
         autoCommit: baseConfig.autoCommit ?? false,
         autoCommitMessage:

--- a/packages/publish/src/index.ts
+++ b/packages/publish/src/index.ts
@@ -54,11 +54,14 @@ export const publishPackages = async ({
 
             const buffer = await miscUtils.bufferStream(pack)
 
+            const globalAccess = config.access
+            const access = globalAccess === 'infer' ? undefined : globalAccess
+
             const body = await npmPublishUtils.makePublishBody(
                 workspace,
                 buffer,
                 {
-                    access: config.access ?? undefined,
+                    access,
                     tag: publishTag,
                     registry: registryUrl,
                 },
@@ -79,7 +82,7 @@ export const publishPackages = async ({
                     )
                 }
                 logging.info(
-                    `[Publish] ${pkgName} (${publishTag}: ${body['dist-tags']?.[publishTag]}, ${registryUrl})`,
+                    `[Publish] ${pkgName} (${publishTag}: ${body['dist-tags']?.[publishTag]}, ${registryUrl}; ${body.access})`,
                     { report: context.report },
                 )
             } catch (e) {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -29,7 +29,7 @@ export interface MonodeployConfiguration {
     changelogFilename?: string
     changesetIgnorePatterns?: Array<string>
     forceWriteChangeFiles: boolean
-    access?: string
+    access?: 'infer' | 'public' | 'restricted'
     persistVersions: boolean
     autoCommit: boolean
     autoCommitMessage: string


### PR DESCRIPTION
https://github.com/tophat/monodeploy/issues/406