### PR TITLE
feat: add commit ignore patterns config option

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -39,7 +39,8 @@ describe('CLI', () => {
                     '--push --persist-versions --access infer --topological --topological-dev --jobs 6 ' +
                     '--auto-commit --auto-commit-message release --plugins plugin-a plugin-b ' +
                     '--max-concurrent-reads 3 --max-concurrent-writes 4 --no-git-tag ' +
-                    '--changeset-ignore-patterns "*.test.js" --prerelease --prerelease-id rc --prerelease-npm-tag beta',
+                    '--changeset-ignore-patterns "*.test.js" --prerelease --prerelease-id rc --prerelease-npm-tag beta ' +
+                    '--commit-ignore-patterns "skip-ci"',
             )
             jest.isolateModules(() => {
                 require('./cli')
@@ -57,6 +58,9 @@ describe('CLI', () => {
                   "changesetFilename": "changes.json",
                   "changesetIgnorePatterns": Array [
                     "*.test.js",
+                  ],
+                  "commitIgnorePatterns": Array [
+                    "skip-ci",
                   ],
                   "conventionalChangelogConfig": "@my/config",
                   "cwd": "/tmp",
@@ -105,6 +109,7 @@ describe('CLI', () => {
                   "changelogFilename": undefined,
                   "changesetFilename": undefined,
                   "changesetIgnorePatterns": undefined,
+                  "commitIgnorePatterns": undefined,
                   "conventionalChangelogConfig": undefined,
                   "cwd": undefined,
                   "dryRun": undefined,
@@ -253,6 +258,7 @@ describe('CLI', () => {
                     prerelease: true,
                     prereleaseId: 'alpha',
                     prereleaseNPMTag: 'beta',
+                    commitIgnorePatterns: ['skip-ci'],
                 }
             `
 
@@ -278,6 +284,9 @@ describe('CLI', () => {
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
                       "changesetIgnorePatterns": undefined,
+                      "commitIgnorePatterns": Array [
+                        "skip-ci",
+                      ],
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": undefined,
                       "dryRun": true,
@@ -366,6 +375,7 @@ describe('CLI', () => {
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
                       "changesetIgnorePatterns": undefined,
+                      "commitIgnorePatterns": undefined,
                       "conventionalChangelogConfig": Object {
                         "name": "@my/config-from-file",
                         "someData": 123,
@@ -453,6 +463,7 @@ describe('CLI', () => {
                         "*.test.js",
                         "*.snap",
                       ],
+                      "commitIgnorePatterns": undefined,
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": "/tmp/cwd",
                       "dryRun": true,
@@ -511,6 +522,7 @@ describe('CLI', () => {
                 maxConcurrentWrites: 11,
                 prerelease: true,
                 prereleaseId: 'beta',
+                commitIgnorePatterns: ['skip-ci'],
             }
         `
 
@@ -521,7 +533,7 @@ describe('CLI', () => {
                 )
                 await fs.writeFile(configFilename, configFileContents, 'utf-8')
                 setArgs(
-                    `--config-file ${configFilename} --git-base-branch next --jobs 3`,
+                    `--config-file ${configFilename} --git-base-branch next --jobs 3 --commit-ignore-patterns "ignore-me"`,
                 )
                 jest.isolateModules(() => {
                     require('./cli')
@@ -538,6 +550,9 @@ describe('CLI', () => {
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
                       "changesetIgnorePatterns": undefined,
+                      "commitIgnorePatterns": Array [
+                        "ignore-me",
+                      ],
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": undefined,
                       "dryRun": true,
@@ -624,6 +639,7 @@ describe('CLI', () => {
                       "changelogFilename": "from_file.changelog.md",
                       "changesetFilename": "from_file.changes.json",
                       "changesetIgnorePatterns": undefined,
+                      "commitIgnorePatterns": undefined,
                       "conventionalChangelogConfig": "@my/config-from-file",
                       "cwd": undefined,
                       "dryRun": true,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -125,6 +125,11 @@ const { argv } = yargs
         description:
             'Globs to use in filtering out files when determining version bumps',
     })
+    .option('commit-ignore-patterns', {
+        type: 'array',
+        description:
+            'Regular expression patterns to filter out commits from version strategy consideration',
+    })
     .option('prerelease', {
         type: 'boolean',
         description: 'Whether to publish using a prerelease strategy',
@@ -192,6 +197,10 @@ if (argv.logLevel !== undefined && argv.logLevel !== null) {
             changesetIgnorePatterns:
                 argv.changesetIgnorePatterns ??
                 configFromFile?.changesetIgnorePatterns ??
+                undefined,
+            commitIgnorePatterns:
+                argv.commitIgnorePatterns ??
+                configFromFile?.commitIgnorePatterns ??
                 undefined,
             changelogFilename:
                 argv.prependChangelog ??

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -30,6 +30,7 @@ export interface ArgOutput {
     prerelease?: boolean
     prereleaseId?: string
     prereleaseNPMTag?: string
+    commitIgnorePatterns?: Array<string>
 }
 
 export type ConfigFile = RecursivePartial<Omit<MonodeployConfiguration, 'cwd'>>

--- a/packages/cli/src/validateConfigFile.ts
+++ b/packages/cli/src/validateConfigFile.ts
@@ -30,6 +30,11 @@ const schema: SchemaObject = {
             nullable: true,
             items: { type: 'string' },
         },
+        commitIgnorePatterns: {
+            type: 'array',
+            nullable: true,
+            items: { type: 'string' },
+        },
         forceWriteChangeFiles: { type: 'boolean', nullable: true },
         access: {
             type: 'string',

--- a/packages/node/src/utils/mergeDefaultConfig.test.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.test.ts
@@ -79,6 +79,7 @@ describe('Config Merging', () => {
             prerelease: true,
             prereleaseId: 'rc',
             prereleaseNPMTag: 'beta',
+            commitIgnorePatterns: ['\\[skip-ci\\]'],
         }
 
         const merged = await mergeDefaultConfig(config)

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -37,6 +37,7 @@ const mergeDefaultConfig = async (
         autoCommit: baseConfig.autoCommit ?? false,
         autoCommitMessage:
             baseConfig.autoCommitMessage ?? 'chore: release [skip ci]',
+        commitIgnorePatterns: baseConfig.commitIgnorePatterns ?? undefined,
         topological: baseConfig.topological ?? false,
         topologicalDev: baseConfig.topologicalDev ?? false,
         jobs: baseConfig.jobs ?? 0,

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -171,6 +171,15 @@ export interface MonodeployConfiguration {
     autoCommitMessage: string
 
     /**
+     * Default: []
+     *
+     * An array of regular expressions which will be used to filter out commits from the
+     * explicit package bump detection. The patterns are matched against commits of the form:
+     * <sha> <newline> <body>
+     */
+    commitIgnorePatterns?: Array<string | RegExp>
+
+    /**
      * Default: false
      *
      * Whether to run the lifecycle scripts of the packages to publish in topological order,


### PR DESCRIPTION
This adds support for an array of regular expressions which can be used to filter out commits from the explicit package bump detection. The patterns are matched against commits of the form <sha><newline><body> in multiline mode.

Related to #402 
