### PR TITLE
fix: re-install project when persisting versions

### DIFF
--- a/e2e-tests/tests/full.test.ts
+++ b/e2e-tests/tests/full.test.ts
@@ -12,7 +12,7 @@ describe('Full E2E', () => {
                     'pkg-2': {
                         dependencies: ['pkg-1'],
                     },
-                    'pkg-3': { dependencies: ['pkg-2'] },
+                    'pkg-3': { dependencies: [['pkg-2', 'workspace:*']] },
                     'pkg-4': { dependencies: ['pkg-3'] },
                     'pkg-isolated': {},
                 },
@@ -51,6 +51,9 @@ describe('Full E2E', () => {
 
                 if (error) console.error(error)
                 expect(error).toBeUndefined()
+
+                // verify yarn.lock is not staged with modifications
+                await exec('yarn && git diff --quiet --exit-code yarn.lock')
 
                 // Locally
                 let localChangeset = JSON.parse(
@@ -123,6 +126,9 @@ describe('Full E2E', () => {
                 expect(error2).toBeUndefined()
 
                 // ---
+
+                // verify yarn.lock is not staged with modifications
+                await exec('yarn && git diff --quiet --exit-code yarn.lock')
 
                 localChangeset = JSON.parse(await readFile('changes.json.tmp'))
                 expect(localChangeset).toEqual({

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -223,7 +223,11 @@ const monodeploy = async (
                             { report },
                         )
                         if (!config.dryRun) {
-                            await project.install({ cache, report })
+                            await project.install({
+                                cache,
+                                report,
+                                immutable: false,
+                            })
                         }
                     },
                 )


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Re-run a yarn install after updating the manifests and publishing in order to ensure the most up to date yarn.lock is committed back to the repository. This is only necessary when persisting versions.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #416, by offering an alternative to the root problem of failing immutable installs

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
