### PR TITLE
fix: re-install project when persisting versions (#417)

### DIFF
--- a/e2e-tests/tests/full.test.ts
+++ b/e2e-tests/tests/full.test.ts
@@ -12,7 +12,7 @@ describe('Full E2E', () => {
                     'pkg-2': {
                         dependencies: ['pkg-1'],
                     },
-                    'pkg-3': { dependencies: ['pkg-2'] },
+                    'pkg-3': { dependencies: [['pkg-2', 'workspace:*']] },
                     'pkg-4': { dependencies: ['pkg-3'] },
                     'pkg-isolated': {},
                 },
@@ -51,6 +51,9 @@ describe('Full E2E', () => {
 
                 if (error) console.error(error)
                 expect(error).toBeUndefined()
+
+                // verify yarn.lock is not staged with modifications
+                await exec('yarn && git diff --quiet --exit-code yarn.lock')
 
                 // Locally
                 let localChangeset = JSON.parse(
@@ -124,6 +127,9 @@ describe('Full E2E', () => {
 
                 // ---
 
+                // verify yarn.lock is not staged with modifications
+                await exec('yarn && git diff --quiet --exit-code yarn.lock')
+
                 localChangeset = JSON.parse(await readFile('changes.json.tmp'))
                 expect(localChangeset).toEqual({
                     'pkg-2': expect.objectContaining({
@@ -168,6 +174,20 @@ describe('Full E2E', () => {
                     (await exec(`git cat-file blob origin/main:changelog.md`))
                         .stdout,
                 ).toEqual(expect.stringContaining('breaking'))
+
+                // assert modified manifests are correct
+                const pkg3Manifest = JSON.parse(
+                    (
+                        await exec(
+                            `git cat-file blob origin/main:packages/pkg-3/package.json`,
+                        )
+                    ).stdout.toString(),
+                )
+                expect(pkg3Manifest.dependencies).toEqual(
+                    expect.objectContaining({
+                        'pkg-2': 'workspace:^1.0.0',
+                    }),
+                )
             },
         }),
         TIMEOUT,


### PR DESCRIPTION
## Description

This PR fixes an issue where after running monodeploy with persistVersions enabled, running `yarn` would produce a modified yarn.lock. This causes "yarn immutable" CI checks to fail. This PR re-installs the project after publishing to ensure the yarn.lock is up-to-date.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #416 

