### PR TITLE
fix: use `tryWorkspaceByIdent` instead of `tryWorkspaceByDescriptor`

### DIFF
--- a/packages/dependencies/src/getTopologicalSort.test.ts
+++ b/packages/dependencies/src/getTopologicalSort.test.ts
@@ -77,6 +77,29 @@ describe('Topological Sort', () => {
             },
         ))
 
+    it('correctly groups packages with dependents using `workspace:` protocol', async () =>
+        withMonorepoContext(
+            {
+                'pkg-1': {
+                    version: '1.0.0',
+                    dependencies: [['pkg-2', 'workspace:^2.0.0']],
+                },
+                'pkg-2': {
+                    version: '2.0.0',
+                },
+            },
+            async (context) => {
+                const workspace1 = identToWorkspace(context, 'pkg-1')
+                const workspace2 = identToWorkspace(context, 'pkg-2')
+
+                const sorted = await getTopologicalSort([
+                    workspace1,
+                    workspace2,
+                ])
+                expect(sorted).toEqual([[workspace2], [workspace1]])
+            },
+        ))
+
     it('detects a cycle', async () =>
         withMonorepoContext(
             {

--- a/packages/dependencies/src/getTopologicalSort.ts
+++ b/packages/dependencies/src/getTopologicalSort.ts
@@ -41,7 +41,7 @@ const getTopologicalSort = async (
             ...(dev ? workspace.manifest.devDependencies.values() : []),
         ]
         for (const descriptor of dependencies) {
-            const child = workspace.project.tryWorkspaceByDescriptor(descriptor)
+            const child = workspace.project.tryWorkspaceByIdent(descriptor)
             if (
                 !child ||
                 !possibleWorkspaces.has(child.anchoredDescriptor.descriptorHash)


### PR DESCRIPTION
## Description

`tryWorkspaceByDescriptor` internally uses `tryWorkspaceByIdent` but in addition to that it checks if the workspace version matches the descriptor version range when using workspace protocol. This resulted in topological order of workspaces calculated incorrectly. See #422 for more context.

## Related Issues

This fixes #422 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
