### PR TITLE
fix: bug where only the latest sha was being written in the changelog

### DIFF
--- a/packages/changelog/src/changelog.ts
+++ b/packages/changelog/src/changelog.ts
@@ -42,7 +42,7 @@ const generateChangelogEntry = async ({
     const conventionalConfig = await resolveConventionalConfig({ config })
 
     const commitsStream = Readable.from(
-        commits.map((commit) => commit.body),
+        commits.map((commit) => `${commit.body}\n-hash-\n${commit.sha}`),
     ).pipe(conventionalCommitsParser(conventionalConfig.parserOpts))
     const conventionalCommits = await readStream<Commit>(commitsStream)
 


### PR DESCRIPTION
Uses side notes from https://github.com/conventional-changelog/conventional-changelog/tree/d7477814399c8687ba705d03dea28f8648c0c855/packages/conventional-commits-parser#other-parts