### PR TITLE
test: coverage for merge commits in commit detection

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,12 @@ codecov:
 notify:
   wait_for_ci: true
 
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+
 comment:
-  layout: "diff"
+  layout: "reach, diff"
+


### PR DESCRIPTION
This prevents the introduction of this reverted commit: https://github.com/tophat/monodeploy/pull/425