### PR TITLE
fix: wrap changelog filename in quotes to perform globbing by git

### DIFF
--- a/packages/node/src/tests/main.test.ts
+++ b/packages/node/src/tests/main.test.ts
@@ -662,7 +662,7 @@ describe('Monodeploy', () => {
                 .filesModified.get(autoCommit.sha)
             expect(autoCommitFiles).toEqual(
                 expect.arrayContaining([
-                    changelogFilename,
+                    `"${changelogFilename}"`,
                     '"**/package.json"',
                 ]),
             )
@@ -724,7 +724,7 @@ describe('Monodeploy', () => {
                 .filesModified.get(autoCommit.sha)
             expect(autoCommitFiles).toEqual(
                 expect.arrayContaining([
-                    changelogFilename,
+                    `"${changelogFilename}"`,
                     '"**/package.json"',
                 ]),
             )

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -35,7 +35,9 @@ const commitPublishChanges = async ({
         // Push artifacts (changelog, package.json changes)
         const files = ['yarn.lock', 'package.json', '"**/package.json"']
         if (config?.changelogFilename) {
-            files.push(config?.changelogFilename.replace('<packageDir>', '**'))
+            files.push(
+                `"${config.changelogFilename.replace('<packageDir>', '**')}"`,
+            )
         }
         await gitAdd(files, { cwd: config.cwd })
         await gitCommit(config.autoCommitMessage, { cwd: config.cwd, context })


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

In some environments (Github Actions) bash doesn't handle `**` globs well thus `git add yarn.lock package.json "**/package.json" **/CHANGELOG.md` doesn't stage `CHANGELOG.md` files if they're nested 2 folders deep:

<img width="1008" alt="Screenshot 2021-08-16 at 14 14 23" src="https://user-images.githubusercontent.com/927591/129568338-7524d9ae-c079-4e9c-ab46-fe54138d7891.png">

To fix this we need to wrap the glob in quotes, so that globbing is performed by Git, not shell.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
