### PR TITLE
fix: overeager detection of cycles in topological sort

### DIFF
--- a/packages/dependencies/src/getTopologicalSort.ts
+++ b/packages/dependencies/src/getTopologicalSort.ts
@@ -1,9 +1,9 @@
-import { DescriptorHash, Workspace } from '@yarnpkg/core'
+import { Workspace } from '@yarnpkg/core'
 
 type Level = number
 
 /**
- * Takes an iterable of workspaces and returns a topologically list:
+ * Takes an iterable of workspaces and returns a topologically sorted list:
  * [ [A, B], [C, D], [E] ]
  */
 const getTopologicalSort = async (
@@ -16,23 +16,18 @@ const getTopologicalSort = async (
             workspace,
         ]),
     )
-    const maxPossibleVisits = possibleWorkspaces.size
 
     const ordered = new Map<Workspace, Level>()
-    const visited = new Map<DescriptorHash, number>()
     const queue = [...possibleWorkspaces.values()]
     while (queue.length) {
         const workspace = queue.shift()!
-        const workspaceHash = workspace.anchoredDescriptor.descriptorHash
-        const visitedCount = visited.get(workspaceHash) ?? 0
-        visited.set(workspaceHash, visitedCount + 1)
-
-        if (visitedCount > maxPossibleVisits) {
-            throw new Error('Unable to determine topological sort. There is likely a cycle.')
-        }
 
         const level = Math.max(ordered.get(workspace) ?? 0, 0)
         ordered.set(workspace, level)
+
+        if (level > possibleWorkspaces.size) {
+            throw new Error('Unable to determine topological sort. There is likely a cycle.')
+        }
 
         const dependencies = [
             ...workspace.manifest.dependencies.values(),

--- a/testUtils/setupMonorepo.ts
+++ b/testUtils/setupMonorepo.ts
@@ -3,10 +3,12 @@ import os from 'os'
 import path from 'path'
 
 import { YarnContext } from '@monodeploy/types'
-import { Cache, StreamReport, structUtils } from '@yarnpkg/core'
+import { Cache, StreamReport, ThrowReport, structUtils } from '@yarnpkg/core'
 import { npath } from '@yarnpkg/fslib'
 
 import { setupContext } from './misc'
+
+const DEBUG = process.env.DEBUG === '1'
 
 async function writeJSON(filename: string, data: Record<string, unknown>): Promise<void> {
     await fs.writeFile(filename, JSON.stringify(data), 'utf-8')
@@ -110,7 +112,9 @@ export default async function setupMonorepo(
 
     await context.project.install({
         cache: await Cache.find(context.configuration),
-        report: new StreamReport({ configuration: context.configuration, stdout: process.stdout }),
+        report: DEBUG
+            ? new StreamReport({ configuration: context.configuration, stdout: process.stdout })
+            : new ThrowReport(),
     })
 
     return context


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Assuming there's a cycle because we've visited a workspace beyond a certain count is an inefficient and incorrect way of determining a cycle. Instead, we look at the max "level" detected. Since all workspaces start at level 0, and increase by when during children detection (and propagation of the levels), the levels should never exceed the max number of edges in a path within a directed DAG. The maximum path size in a directed DAG is the number of nodes - 1. Exceeding this implies a directed edge to a node already part of the path, which is a cycle.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #442, and included the example from #442 as a test.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
