### PR TITLE
fix: change access config option default from public to infer

### DIFF
--- a/gatsby/src/pages/getting-started.mdx
+++ b/gatsby/src/pages/getting-started.mdx
@@ -34,8 +34,6 @@ yarn monodeploy --help
 
 or see the [Configuration](../configuration) page for more details.
 
-**Private Packages**: If using Monodeploy in a project with a mix of private and public packages, you will want to set the config option `access` to "infer" to prevent accidentally publishing your private packages with public access. See the documentation for [access](../configuration#schema-option-access).
-
 ### API
 
 Monodeploy supports both a Command Line Interface, as well as a Node API.

--- a/packages/node/src/tests/main.test.ts
+++ b/packages/node/src/tests/main.test.ts
@@ -128,7 +128,7 @@ describe('Monodeploy', () => {
 
         expect(spyPublish.mock.calls[0][2]).toEqual(
             expect.objectContaining({
-                access: 'public',
+                access: undefined, // when set to infer, we let Yarn choose
             }),
         )
         spyPublish.mockClear()
@@ -147,12 +147,12 @@ describe('Monodeploy', () => {
 
         await monodeploy({
             ...monodeployConfig,
-            access: 'infer',
+            access: 'public',
         })
 
         expect(spyPublish.mock.calls[0][2]).toEqual(
             expect.objectContaining({
-                access: undefined,
+                access: 'public',
             }),
         )
         spyPublish.mockClear()

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -26,7 +26,7 @@ const mergeDefaultConfig = async (
         changelogFilename: baseConfig.changelogFilename ?? undefined,
         changesetIgnorePatterns: baseConfig.changesetIgnorePatterns ?? [],
         forceWriteChangeFiles: baseConfig.forceWriteChangeFiles ?? false,
-        access: baseConfig.access ?? 'public',
+        access: baseConfig.access ?? 'infer',
         persistVersions: baseConfig.persistVersions ?? false,
         autoCommit: baseConfig.autoCommit ?? false,
         autoCommitMessage: baseConfig.autoCommitMessage ?? 'chore: release [skip ci]',

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -135,12 +135,10 @@ export interface MonodeployConfiguration {
     forceWriteChangeFiles: boolean
 
     /**
-     * Default: public
+     * Default: infer
      *
      * This overrides the access defined in the publishConfig of individual
      * workspaces. Set this to 'infer' to respect individual workspace configurations.
-     *
-     * **Caution**: The default may be too open and will be changed in a future major release.
      */
     access?: 'infer' | 'public' | 'restricted'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22650,7 +22650,7 @@ resolve@^2.0.0-next.3:
 
 "typescript@patch:typescript@~4.4.2#~builtin<compat/typescript>":
   version: 4.4.2
-  resolution: "typescript@patch:typescript@npm%3A4.4.2#~builtin<compat/typescript>::version=4.4.2&hash=ddd1e8"
+  resolution: "typescript@patch:typescript@npm%3A4.4.2#~builtin<compat/typescript>::version=4.4.2&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
@@ -22660,11 +22660,11 @@ resolve@^2.0.0-next.3:
 
 "typescript@patch:typescript@~4.5.2#~builtin<compat/typescript>":
   version: 4.5.2
-  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=ddd1e8"
+  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 24a439e062a05e3285a4f0e8a40644116ecdca89f3e908bed01e5a01b9aee747e3bcf0e85fe9e017e5ebf0c0863437c39479f2616f55a244c2d82d37022cdc4f
+  checksum: 53838d56aba6fcc947d63aa0771e5d966b1b648fddafed6e221d7f38c71219c4e036ece8cfe9e35ed80cf5a35ff4eb958934c993f99c3233773ec4f9ccd53f69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BREAKING CHANGE: Change the default of the 'access' config option from public to infer. This reduces risk of accidental publish of private packages. The infer option respects the user's yarnrc.yml config, as well as publishConfig.access manifest field.

Related: https://github.com/tophat/monodeploy/issues/406