### PR TITLE
feat: tag the same commit which includes publish artifacts, #402

### DIFF
--- a/packages/changelog/src/writeChangesetFile.test.ts
+++ b/packages/changelog/src/writeChangesetFile.test.ts
@@ -69,7 +69,7 @@ describe('writeChangesetFile', () => {
                     },
                 ],
             ]),
-            createdGitTags: new Map([
+            gitTags: new Map([
                 ['pkg-1', 'pkg-1@2.0.0'],
                 ['pkg-2', 'pkg-1@4.6.0'],
             ]),

--- a/packages/changelog/src/writeChangesetFile.ts
+++ b/packages/changelog/src/writeChangesetFile.ts
@@ -19,14 +19,14 @@ const writeChangesetFile = async ({
     previousTags,
     nextTags,
     versionStrategies,
-    createdGitTags,
+    gitTags,
 }: {
     config: MonodeployConfiguration
     context: YarnContext
     previousTags: PackageVersionMap
     nextTags: PackageVersionMap
     versionStrategies: PackageStrategyMap
-    createdGitTags?: Map<string, string>
+    gitTags?: Map<string, string>
 }): Promise<ChangesetSchema> => {
     const changesetData: ChangesetSchema = {}
 
@@ -45,7 +45,7 @@ const writeChangesetFile = async ({
             version: newVersion,
             previousVersion: previousVersion,
             changelog,
-            tag: createdGitTags?.get(packageName) ?? null,
+            tag: gitTags?.get(packageName) ?? null,
             strategy: versionStrategy?.type ?? null,
         }
     }

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -2,27 +2,22 @@ import { gitAdd, gitCommit, gitGlob, gitPull, gitPush, gitPushTags } from '@mono
 import logging from '@monodeploy/logging'
 import { MonodeployConfiguration, YarnContext } from '@monodeploy/types'
 
+import createReleaseGitTags from './createReleaseGitTags'
+
 const commitPublishChanges = async ({
     config,
     context,
+    gitTags,
 }: {
     config: MonodeployConfiguration
     context: YarnContext
+    gitTags?: Map<string, string>
 }): Promise<void> => {
     if (config.dryRun) {
         logging.info('[Publish] Committing changes', {
             report: context?.report,
         })
         return
-    }
-
-    // Push tags
-    if (config.git.push && config.git.tag) {
-        await gitPushTags({
-            cwd: config.cwd,
-            remote: config.git.remote,
-            context,
-        })
     }
 
     if (config.autoCommit) {
@@ -35,14 +30,40 @@ const commitPublishChanges = async ({
 
         await gitAdd(files, { cwd: config.cwd, context })
         await gitCommit(config.autoCommitMessage, { cwd: config.cwd, context })
+    }
 
-        if (config.git.push) {
-            await gitPull({
+    if (config.git.tag && gitTags) {
+        // Tag commit
+        await createReleaseGitTags({
+            config,
+            context,
+            gitTags,
+        })
+
+        // Push tags only outside of auto-commit mode, otherwise
+        // we'll push them after we push the commit
+        if (config.git.push && !config.autoCommit) {
+            await gitPushTags({
                 cwd: config.cwd,
                 remote: config.git.remote,
                 context,
             })
-            await gitPush({
+        }
+    }
+
+    if (config.autoCommit && config.git.push) {
+        await gitPull({
+            cwd: config.cwd,
+            remote: config.git.remote,
+            context,
+        })
+        await gitPush({
+            cwd: config.cwd,
+            remote: config.git.remote,
+            context,
+        })
+        if (config.git.tag && gitTags) {
+            await gitPushTags({
                 cwd: config.cwd,
                 remote: config.git.remote,
                 context,

--- a/packages/publish/src/createReleaseGitTags.ts
+++ b/packages/publish/src/createReleaseGitTags.ts
@@ -1,44 +1,28 @@
 import { gitTag } from '@monodeploy/git'
 import logging from '@monodeploy/logging'
-import type { MonodeployConfiguration, PackageVersionMap, YarnContext } from '@monodeploy/types'
+import type { MonodeployConfiguration, YarnContext } from '@monodeploy/types'
 
 async function createReleaseGitTags({
     config,
     context,
-    versions,
+    gitTags,
 }: {
     config: MonodeployConfiguration
     context: YarnContext
-    versions: PackageVersionMap
-}): Promise<Map<string, string>> {
-    const tags = await Promise.all(
-        [...versions.entries()].map(async (packageVersionEntry: string[]) => {
-            const [packageIdent, packageVersion] = packageVersionEntry
-            const tag = `${packageIdent}@${packageVersion}`
-
-            try {
-                if (!config.dryRun) {
-                    await gitTag(tag, { cwd: config.cwd, context })
-                }
-
-                logging.info(`[Tag] ${tag}`, { report: context.report })
-
-                return [packageIdent, tag]
-            } catch (err) {
-                logging.error(`[Tag] Failed ${tag}`, { report: context.report })
-                logging.error(err, { report: context.report })
+    gitTags: Map<string, string>
+}): Promise<void> {
+    for (const tag of gitTags.values()) {
+        try {
+            if (!config.dryRun) {
+                await gitTag(tag, { cwd: config.cwd, context })
             }
-            return null
-        }),
-    )
 
-    const packageTags = new Map<string, string>()
-    for (const tag of tags) {
-        if (!tag) continue
-        packageTags.set(tag[0], tag[1])
+            logging.info(`[Tag] ${tag}`, { report: context.report })
+        } catch (err) {
+            logging.error(`[Tag] Failed ${tag}`, { report: context.report })
+            logging.error(err, { report: context.report })
+        }
     }
-
-    return packageTags
 }
 
 export default createReleaseGitTags

--- a/packages/publish/src/determineGitTags.ts
+++ b/packages/publish/src/determineGitTags.ts
@@ -1,0 +1,23 @@
+import type { PackageVersionMap } from '@monodeploy/types'
+
+async function determineGitTags({
+    versions,
+}: {
+    versions: PackageVersionMap
+}): Promise<Map<string, string>> {
+    const tags = [...versions.entries()].map((packageVersionEntry: string[]) => {
+        const [packageIdent, packageVersion] = packageVersionEntry
+        const tag = `${packageIdent}@${packageVersion}`
+        return [packageIdent, tag]
+    })
+
+    const packageTags = new Map<string, string>()
+    for (const tag of tags) {
+        if (!tag) continue
+        packageTags.set(tag[0], tag[1])
+    }
+
+    return packageTags
+}
+
+export default determineGitTags

--- a/packages/publish/src/index.ts
+++ b/packages/publish/src/index.ts
@@ -7,12 +7,12 @@ import { packUtils } from '@yarnpkg/plugin-pack'
 import pLimit from 'p-limit'
 
 import commitPublishChanges from './commitPublishChanges'
-import createReleaseGitTags from './createReleaseGitTags'
+import determineGitTags from './determineGitTags'
 import { getPublishRegistryUrl } from './getPublishConfig'
 import getWorkspacesToPublish from './getWorkspacesToPublish'
 import { prepareForPack, prepareForPublish } from './prepare'
 
-export { commitPublishChanges, getWorkspacesToPublish, createReleaseGitTags }
+export { determineGitTags, commitPublishChanges, getWorkspacesToPublish }
 
 export const publishPackages = async ({
     config,


### PR DESCRIPTION
BREAKING CHANGE: Monodeploy no longer tags the commit containing the code changes, but rather tags the later commit which contains the package.json changes and other publish artifacts. This is more inline with how Lerna operates and means the tag will match the version in the package.json, as well as the changelog files. If there is interest in adding back the old behaviour behind a configuration option, please open a GitHub issue.

We still need to update the gatsby documentation to reflect the pipeline change.