### PR TITLE
fix: use per-scope fetch registry from .yarnrc.yml, #457

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -29,7 +29,6 @@ import { npath } from '@yarnpkg/fslib'
 import { AsyncSeriesHook } from 'tapable'
 
 import getCompatiblePluginConfiguration from './utils/getCompatiblePluginConfiguration'
-import { getFetchRegistryUrl } from './utils/getRegistryUrl'
 import mergeDefaultConfig from './utils/mergeDefaultConfig'
 
 const monodeploy = async (
@@ -88,17 +87,10 @@ const monodeploy = async (
             report,
         })
 
-        const defaultFetchRegistryUrl = await getFetchRegistryUrl({
-            config,
-            context,
-        })
-        logging.debug(`[Config] Default Registry Fetch Url: ${defaultFetchRegistryUrl}`, { report })
-
         // Fetch latest package versions for workspaces
         const registryTags = await getLatestPackageTags({
             config,
             context,
-            registryUrl: defaultFetchRegistryUrl,
         })
 
         // Determine version bumps via commit messages

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -16,8 +16,8 @@ export interface MonodeployConfiguration {
 
     /**
      * The NPM registry URL for fetching package information, and publishing
-     * packages outside of dry run. Note that this overrides any
-     * publishConfig.registryUrl or Yarn RC configuration.
+     * packages. Note that this overrides any publishConfig.registryUrl or
+     * Yarn RC configuration.
      *
      * @default [Yarn Configuration](https://yarnpkg.com/configuration/yarnrc)
      */

--- a/packages/versions/src/getLatestPackageTags.test.ts
+++ b/packages/versions/src/getLatestPackageTags.test.ts
@@ -60,7 +60,6 @@ describe('getLatestPackageTags', () => {
         const tags = await getLatestPackageTags({
             config,
             context,
-            registryUrl: config.registryUrl ?? 'https://example.org/',
         })
         for (const tagPair of tags) {
             const tag = tagPair[1]
@@ -89,7 +88,6 @@ describe('getLatestPackageTags', () => {
         const tags = await getLatestPackageTags({
             config,
             context,
-            registryUrl: config.registryUrl ?? 'https://example.org/',
         })
 
         const expectedTags = new Map([
@@ -120,7 +118,6 @@ describe('getLatestPackageTags', () => {
                 await getLatestPackageTags({
                     config,
                     context,
-                    registryUrl: config.registryUrl ?? 'https://example.org/',
                 }),
         ).rejects.toEqual(mockError)
 
@@ -147,7 +144,6 @@ describe('getLatestPackageTags', () => {
         const tags = await getLatestPackageTags({
             config,
             context,
-            registryUrl: config.registryUrl,
         })
         for (const tagPair of tags) {
             const tag = tagPair[1]
@@ -174,7 +170,6 @@ describe('getLatestPackageTags', () => {
         const tags = await getLatestPackageTags({
             config,
             context,
-            registryUrl: config.registryUrl ?? 'https://example.org/',
         })
 
         expect(tags.keys()).not.toContain('pkg-2')

--- a/packages/versions/src/getRegistryUrl.test.ts
+++ b/packages/versions/src/getRegistryUrl.test.ts
@@ -17,7 +17,11 @@ describe('getFetchRegistryUrl', () => {
                     noRegistry: true,
                 }
                 config.registryUrl = 'http://example.com'
-                const url = await getFetchRegistryUrl({ config, context })
+                const url = await getFetchRegistryUrl({
+                    config,
+                    context,
+                    workspace: context.workspace,
+                })
                 expect(url).toBeNull()
             },
         ))
@@ -33,7 +37,11 @@ describe('getFetchRegistryUrl', () => {
                     baseBranch: 'main',
                 })
                 config.registryUrl = 'http://example.com'
-                const url = await getFetchRegistryUrl({ config, context })
+                const url = await getFetchRegistryUrl({
+                    config,
+                    context,
+                    workspace: context.workspace,
+                })
                 expect(url).toEqual(config.registryUrl)
             },
         ))
@@ -49,7 +57,11 @@ describe('getFetchRegistryUrl', () => {
                     baseBranch: 'main',
                 })
                 config.registryUrl = undefined
-                const url = await getFetchRegistryUrl({ config, context })
+                const url = await getFetchRegistryUrl({
+                    config,
+                    context,
+                    workspace: context.workspace,
+                })
                 expect(url).toMatchInlineSnapshot('"https://registry.yarnpkg.com"')
             },
         ))

--- a/packages/versions/src/getRegistryUrl.ts
+++ b/packages/versions/src/getRegistryUrl.ts
@@ -1,12 +1,15 @@
 import type { MonodeployConfiguration, YarnContext } from '@monodeploy/types'
+import { Workspace } from '@yarnpkg/core'
 import * as pluginNPM from '@yarnpkg/plugin-npm'
 
 export const getFetchRegistryUrl = async ({
     config,
     context,
+    workspace,
 }: {
     config: MonodeployConfiguration
     context: YarnContext
+    workspace: Workspace
 }): Promise<string | null> => {
     if (config.noRegistry) {
         return null
@@ -17,7 +20,7 @@ export const getFetchRegistryUrl = async ({
         return pluginNPM.npmConfigUtils.normalizeRegistry(configRegistryUrl)
     }
 
-    return await pluginNPM.npmConfigUtils.getDefaultRegistry({
+    return await pluginNPM.npmConfigUtils.getScopeRegistry(workspace.manifest.name?.scope ?? null, {
         configuration: context.configuration,
         type: pluginNPM.npmConfigUtils.RegistryType.FETCH_REGISTRY,
     })


### PR DESCRIPTION
https://github.com/yarnpkg/berry/blob/c57f788778df611310f0e242ee9f805f84623139/packages/plugin-npm/sources/npmConfigUtils.ts#L37