### PR TITLE
fix: perform no-op if base branch is tagged

### DIFF
--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -113,7 +113,7 @@ export const gitLastTaggedCommit = async ({
     cwd: string
     context?: YarnContext
     prerelease?: boolean
-}): Promise<string> => {
+}): Promise<{ sha: string; tag: string | null }> => {
     let command = "describe --abbrev=0 --match '*@*[[:digit:]]*.[[:digit:]]*.[[:digit:]]*'"
 
     if (!prerelease) {
@@ -123,7 +123,7 @@ export const gitLastTaggedCommit = async ({
         command = `${command} --exclude '*@*[[:digit:]]*.[[:digit:]]*.[[:digit:]]*-*'`
     }
 
-    let tag = 'HEAD'
+    let tag: string | null = null
 
     try {
         tag = (await git(command, { cwd, context })).stdout.trim()
@@ -133,14 +133,16 @@ export const gitLastTaggedCommit = async ({
         })
     }
 
-    return (
-        await git(`rev-list -1 ${tag}`, {
+    const sha = (
+        await git(`rev-list -1 ${tag ?? 'HEAD'}`, {
             cwd,
             context,
         })
     ).stdout
         .toString()
         .trim()
+
+    return { sha, tag }
 }
 
 export const gitGlob = async (

--- a/packages/git/src/index.mocked.test.ts
+++ b/packages/git/src/index.mocked.test.ts
@@ -64,7 +64,7 @@ describe('@monodeploy/git (mocked invariants)', () => {
             })
         ).stdout
 
-        expect(lastTaggedSha).toEqual(actualSha.trim())
+        expect(lastTaggedSha.sha).toEqual(actualSha.trim())
     })
 
     it('gitPushTags pushes to remote', async () => {
@@ -88,6 +88,6 @@ describe('@monodeploy/git (mocked invariants)', () => {
         ).stdout
         await cleanUp([upstreamContext.project.cwd])
 
-        expect(remoteTags).toEqual(expect.stringContaining(lastTaggedSha.trim()))
+        expect(remoteTags).toEqual(expect.stringContaining(lastTaggedSha.sha.trim()))
     })
 })

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -36,7 +36,6 @@ const monodeploy = async (
     baseConfig: RecursivePartial<MonodeployConfiguration>,
 ): Promise<ChangesetSchema> => {
     const config: MonodeployConfiguration = await mergeDefaultConfig(baseConfig)
-
     if (config.cwd === typeof undefined) {
         throw new Error('Invalid cwd.')
     }

--- a/packages/node/src/utils/mergeDefaultConfig.test.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.test.ts
@@ -36,12 +36,11 @@ describe('Config Merging', () => {
         delete process.env.MONODEPLOY_LOG_LEVEL
     })
 
-    it('resolves git base branch and sha', async () => {
+    it('resolves commit sha', async () => {
         mockGit._commitFiles_('sha1', 'feat: some new feature!', ['./packages/pkg-1/README.md'])
         mockGit.gitTag('v1.0.0', { cwd: '/tmp' })
 
         const merged = await mergeDefaultConfig({ cwd: '/tmp' })
-        expect(merged.git.baseBranch).toBe('sha1')
         expect(merged.git.commitSha).toBe('sha:HEAD')
     })
 

--- a/packages/node/src/utils/mergeDefaultConfig.ts
+++ b/packages/node/src/utils/mergeDefaultConfig.ts
@@ -1,4 +1,4 @@
-import { gitLastTaggedCommit, gitResolveSha } from '@monodeploy/git'
+import { gitResolveSha } from '@monodeploy/git'
 import type { MonodeployConfiguration, RecursivePartial } from '@monodeploy/types'
 import { npath } from '@yarnpkg/fslib'
 
@@ -14,8 +14,7 @@ const mergeDefaultConfig = async (
         cwd,
         dryRun: baseConfig.dryRun ?? false,
         git: {
-            baseBranch:
-                baseConfig.git?.baseBranch ?? (await gitLastTaggedCommit({ cwd, prerelease })),
+            baseBranch: baseConfig.git?.baseBranch,
             commitSha: baseConfig.git?.commitSha ?? (await gitResolveSha('HEAD', { cwd })),
             remote: baseConfig.git?.remote ?? 'origin',
             push: baseConfig.git?.push ?? false,

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -51,7 +51,7 @@ export interface MonodeployConfiguration {
          * discovery. If not set, this will default to the last tagged commit.
          * You usually do not want to set this.
          */
-        baseBranch: string
+        baseBranch?: string
 
         /**
          * Default: HEAD


### PR DESCRIPTION
If no baseBranch is supplied, monodeploy defaults to the last tagged commit. If the last tagged commit is the HEAD commit, monodeploy should not perform any actions as everything is already up-to-date.
