### PR TITLE
feat: consider private workspaces when determining updates

### DIFF
--- a/gatsby/src/pages/faq.mdx
+++ b/gatsby/src/pages/faq.mdx
@@ -31,7 +31,19 @@ In addition to the version strategies associated with packages explicitly modifi
 
 As an added benefit, downstream projects using systems like Renovate or Dependabot, will also receive updates for Package-A that will bring in the updated Package-B.
 
-If there is a use case where you believe this behaviour is unwarranted, please open an issue and we'll be glad to discuss.
+If there is a use case where you believe this behaviour is does not make sense, please open an issue and we'll be glad to discuss.
+
+Note that when using package groups (equivalent of Lerna's fixed mode), the highest version strategy from among each group is chosen. In this case, you may find a dependent package with a minor or even major version bump, assuming such a strategy exists for an intentional bump within said group.
+
+### How does Monodeploy handle private packages?
+
+Private packages, i.e. packages containing a `private: true` field in their manifest, are includes as part of dependency graph traversal and in determining version strategies, but are not published to any registry. Monodeploy filters out private packages from git tag creation as well.
+
+Note that the top level workspace is a special case. It is neither published, nor considered part of the dependency graph. In other words, all dependency paths are terminated at the top level workspace rather than traverse through this workspace.
+
+### How can I manually trigger a release (i.e. ignore commits)?
+
+Monodeploy is intended to be entirely automated based on semantic commits. As a result we have not prioritized any manual modes. If manual releases are what you prefer, you may be more interested in the official Yarn Version Plugin. Otherwise, feel free to open a GitHub issue to discuss.
 
 ### How can I achieve behaviour similar to Lerna's fixed version mode?
 

--- a/gatsby/src/pages/getting-started.mdx
+++ b/gatsby/src/pages/getting-started.mdx
@@ -16,9 +16,8 @@ yarn monodeploy --dry-run
 
 Edit your project's root `package.json`:
 
-1. Set `"private": true`
-2. Set "workspaces": ["packages/*"] (you can use a different glob to match your monorepo layout)
-3. Create a `monodeploy.config.js` file and set it to:
+1. Set "workspaces": ["packages/*"] (you can use a different glob to match your monorepo layout)
+2. Create a `monodeploy.config.js` file and set it to:
 
   ```js
   module.exports = { preset: 'monodeploy/preset-recommended' }

--- a/packages/dependencies/src/getDependents.test.ts
+++ b/packages/dependencies/src/getDependents.test.ts
@@ -53,7 +53,7 @@ describe('@monodeploy/dependencies', () => {
         expect(dependents).toEqual(new Set(['pkg-6']))
     })
 
-    it('Ignores private dependents', async () => {
+    it('Considers private dependents', async () => {
         const config = await getMonodeployConfig({
             cwd: context.project.cwd,
             baseBranch: 'main',
@@ -62,7 +62,7 @@ describe('@monodeploy/dependencies', () => {
 
         // pkg-5 is a private dependent of pk-4
         const dependents = await getDependents(config, context, new Set(['pkg-4']))
-        expect(dependents).toEqual(new Set())
+        expect(dependents).toEqual(new Set(['pkg-5']))
     })
 
     it('Only counts dependents once', async () => {

--- a/packages/dependencies/src/getDependents.ts
+++ b/packages/dependencies/src/getDependents.ts
@@ -7,10 +7,15 @@ const getDependents = async (
     packageNames: Set<string>,
 ): Promise<Set<string>> => {
     const identToWorkspace = new Map<string, Workspace>()
+    const topLevelWorkspace = context.project.topLevelWorkspace
 
     // Enable easy lookup of workspace name to workspace
     for (const workspace of context.project.workspaces) {
-        if (workspace.manifest.private || !workspace.manifest.name) continue
+        const isTopLevel = structUtils.areDescriptorsEqual(
+            workspace.anchoredDescriptor,
+            topLevelWorkspace.anchoredDescriptor,
+        )
+        if (isTopLevel || !workspace.manifest.name) continue
         const ident = structUtils.stringifyIdent(workspace.manifest.name)
         identToWorkspace.set(ident, workspace)
     }
@@ -25,7 +30,7 @@ const getDependents = async (
             for (const dependency of dependencies.values()) {
                 const dependencyIdent = structUtils.stringifyIdent(dependency)
 
-                // Prune invalid workspace candidates (e.g. private)
+                // Prune invalid workspace candidates (e.g. top level)
                 if (!identToWorkspace.has(dependencyIdent)) continue
 
                 const dependents = identToDirectDependents.get(dependencyIdent) ?? new Set<string>()

--- a/packages/versions/src/applyReleases.ts
+++ b/packages/versions/src/applyReleases.ts
@@ -143,12 +143,14 @@ const applyReleases = async ({
         if (!version) continue
 
         for (const packageName of group) {
+            // skip packages with no associated versions (e.g. private packages)
+            if (!registryTags.get(packageName)) continue
+
             updatedRegistryTags.set(packageName, {
                 ...updatedRegistryTags.get(packageName)!,
                 next: version,
             })
             const update = updatedRegistryTags.get(packageName)!
-
             if (isFullyIndependent) {
                 logging.info(
                     `[Version Change] ${packageName}: ${update.previous} -> ${update.next} (${

--- a/packages/versions/src/getExplicitVersionStrategies.ts
+++ b/packages/versions/src/getExplicitVersionStrategies.ts
@@ -49,6 +49,7 @@ const getModifiedPackages = async ({
         new Set(),
     )
 
+    const topLevelDescriptor = context.project.topLevelWorkspace.anchoredDescriptor
     const ignorePatterns = config.changesetIgnorePatterns ?? []
 
     const modifiedPackages = [...uniquePaths].reduce(
@@ -60,8 +61,15 @@ const getModifiedPackages = async ({
                     )
                     const ident = workspace?.manifest?.name
                     if (!ident) throw new Error('Missing workspace identity.')
+
                     const packageName = structUtils.stringifyIdent(ident)
-                    if (packageName && !workspace.manifest.private) {
+                    if (
+                        packageName &&
+                        !structUtils.areDescriptorsEqual(
+                            topLevelDescriptor,
+                            workspace.anchoredDescriptor,
+                        )
+                    ) {
                         modifiedPackages.push(packageName)
                     }
                 } catch (err) {

--- a/packages/versions/src/mergeVersionStrategies.ts
+++ b/packages/versions/src/mergeVersionStrategies.ts
@@ -38,7 +38,14 @@ const mergeVersionStrategies = async ({
     const workspaces = new Map<string, Workspace>()
     const groups = new Map<string, Set<string>>()
     for (const workspace of context.project.workspaces) {
-        if (workspace.manifest.private || !workspace.manifest.name) continue
+        if (
+            structUtils.areDescriptorsEqual(
+                context.project.topLevelWorkspace.anchoredDescriptor,
+                workspace.anchoredDescriptor,
+            ) ||
+            !workspace.manifest.name
+        )
+            continue
         const ident = structUtils.stringifyIdent(workspace.manifest.name)
         if (strategies.has(ident)) {
             workspaces.set(ident, workspace)


### PR DESCRIPTION
BREAKING CHANGE: Private workspaces are now no longer pruned prior to dependency graph traversal and when considering version strategies for a group. This means you can create a private workspace as a devDependency of other packages and updates to that private workspace will propagate to the dependents with the correct version strategy -- assuming all these packages are in the same group. The private package, although considered when determining the version strategy, is not published.

https://github.com/tophat/monodeploy/issues/467
