### PR TITLE
feat: support publishing the top level workspace

### DIFF
--- a/packages/io/src/getPackageJsonPaths.ts
+++ b/packages/io/src/getPackageJsonPaths.ts
@@ -7,9 +7,10 @@ const getPackageJsonPaths = async (
     config: MonodeployConfiguration,
     context: YarnContext,
 ): Promise<string[]> => {
-    return [...context.project.topLevelWorkspace.workspacesCwds].map((wCwd) =>
-        path.resolve(config.cwd, npath.fromPortablePath(wCwd), 'package.json'),
-    )
+    return [
+        context.project.topLevelWorkspace.cwd,
+        ...context.project.topLevelWorkspace.workspacesCwds,
+    ].map((wCwd) => path.resolve(config.cwd, npath.fromPortablePath(wCwd), 'package.json'))
 }
 
 export default getPackageJsonPaths

--- a/packages/node/src/tests/nonMonorepo.test.ts
+++ b/packages/node/src/tests/nonMonorepo.test.ts
@@ -1,0 +1,162 @@
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+
+import * as git from '@monodeploy/git'
+import { LOG_LEVELS } from '@monodeploy/logging'
+import { setupMonorepo } from '@monodeploy/test-utils'
+import type { CommitMessage, MonodeployConfiguration, YarnContext } from '@monodeploy/types'
+import { npath } from '@yarnpkg/fslib'
+import * as npm from '@yarnpkg/plugin-npm'
+
+import monodeploy from '..'
+
+jest.mock('@yarnpkg/plugin-npm')
+jest.mock('@monodeploy/git')
+
+const mockGit = git as jest.Mocked<
+    typeof git & {
+        _reset_: () => void
+        _commitFiles_: (sha: string, commit: string, files: string[]) => void
+        _getPushedTags_: () => string[]
+        _getTags_: () => string[]
+        _getRegistry_: () => {
+            commits: CommitMessage[]
+            filesModified: Map<string, string[]>
+            tags: string[]
+            pushedTags: string[]
+            lastTaggedCommit?: string
+            pushedCommits: string[]
+            stagedFiles: string[]
+        }
+    }
+>
+const mockNPM = npm as jest.Mocked<
+    typeof npm & {
+        _reset_: () => void
+        _setTag_: (pkgName: string, tagValue: string, tagKey?: string) => void
+    }
+>
+
+const setupExampleMonorepo = async (): Promise<YarnContext> => {
+    const context = await setupMonorepo(
+        {},
+        {
+            root: {
+                name: 'pkg-1',
+                version: '0.0.1',
+                private: false,
+                dependencies: {
+                    '@tophat/conventional-changelog-config': '^0.5.0',
+                },
+            },
+        },
+    )
+    return context
+}
+
+describe('Non-monorepos (single package)', () => {
+    const monodeployConfig: MonodeployConfiguration = {
+        cwd: '/tmp/to-be-overwritten-by-before-each',
+        dryRun: false,
+        noRegistry: false,
+        autoCommit: false,
+        autoCommitMessage: 'chore: release [skip ci]',
+        git: {
+            baseBranch: 'main',
+            commitSha: 'HEAD',
+            remote: 'origin',
+            push: true,
+            tag: true,
+        },
+        conventionalChangelogConfig: '@tophat/conventional-changelog-config',
+        access: 'public',
+        persistVersions: false,
+        topological: false,
+        topologicalDev: false,
+        jobs: 0,
+        forceWriteChangeFiles: false,
+        maxConcurrentReads: 2,
+        maxConcurrentWrites: 2,
+        prerelease: false,
+        prereleaseId: 'rc',
+        prereleaseNPMTag: 'next',
+    }
+
+    beforeAll(async () => {
+        process.env.MONODEPLOY_LOG_LEVEL = String(LOG_LEVELS.ERROR)
+    })
+
+    beforeEach(async () => {
+        const context = await setupExampleMonorepo()
+        monodeployConfig.cwd = npath.fromPortablePath(context.project.cwd)
+    })
+
+    afterEach(async () => {
+        mockGit._reset_()
+        mockNPM._reset_()
+        try {
+            await fs.rm(monodeployConfig.cwd, { recursive: true, force: true })
+        } catch {}
+    })
+
+    afterAll(() => {
+        delete process.env.MONODEPLOY_LOG_LEVEL
+    })
+
+    it('publishes changed workspaces with distinct version stategies and commits', async () => {
+        mockNPM._setTag_('pkg-1', '0.0.1')
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', ['./README.md'])
+
+        const result = await monodeploy(monodeployConfig)
+
+        // pkg-1 is explicitly updated with minor bump
+        expect(result['pkg-1'].version).toBe('0.1.0')
+        expect(result['pkg-1'].changelog).toEqual(expect.stringContaining('some new feature'))
+
+        expect(mockGit._getPushedTags_()).toEqual(['pkg-1@0.1.0'])
+    })
+
+    it('updates changelog and changeset', async () => {
+        mockNPM._setTag_('pkg-1', '0.0.1')
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', ['./README.md'])
+
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'changelog-'))
+        const changelogFilename = await path.join(tempDir, 'changelog.md')
+        const changesetFilename = await path.join(tempDir, 'changeset.json')
+
+        try {
+            const changelogTemplate = [
+                '# Changelog',
+                'Some blurb',
+                '<!-- MONODEPLOY:BELOW -->',
+                '## Old Versions',
+                'Content',
+            ].join('\n')
+            await fs.writeFile(changelogFilename, changelogTemplate, {
+                encoding: 'utf-8',
+            })
+
+            await monodeploy({
+                ...monodeployConfig,
+                changelogFilename,
+                changesetFilename,
+            })
+
+            const updatedChangelog = await fs.readFile(changelogFilename, {
+                encoding: 'utf-8',
+            })
+
+            // assert it contains the new entry
+            expect(updatedChangelog).toEqual(expect.stringContaining('some new feature'))
+
+            // assert it contains the old entries
+            expect(updatedChangelog).toEqual(expect.stringContaining('Old Versions'))
+        } finally {
+            try {
+                await fs.unlink(changelogFilename)
+                await fs.rm(tempDir, { recursive: true, force: true })
+            } catch {}
+        }
+    })
+})

--- a/packages/versions/src/getExplicitVersionStrategies.ts
+++ b/packages/versions/src/getExplicitVersionStrategies.ts
@@ -49,7 +49,6 @@ const getModifiedPackages = async ({
         new Set(),
     )
 
-    const topLevelDescriptor = context.project.topLevelWorkspace.anchoredDescriptor
     const ignorePatterns = config.changesetIgnorePatterns ?? []
 
     const modifiedPackages = [...uniquePaths].reduce(
@@ -63,13 +62,7 @@ const getModifiedPackages = async ({
                     if (!ident) throw new Error('Missing workspace identity.')
 
                     const packageName = structUtils.stringifyIdent(ident)
-                    if (
-                        packageName &&
-                        !structUtils.areDescriptorsEqual(
-                            topLevelDescriptor,
-                            workspace.anchoredDescriptor,
-                        )
-                    ) {
+                    if (packageName) {
                         modifiedPackages.push(packageName)
                     }
                 } catch (err) {

--- a/packages/versions/src/mergeVersionStrategies.ts
+++ b/packages/versions/src/mergeVersionStrategies.ts
@@ -38,14 +38,7 @@ const mergeVersionStrategies = async ({
     const workspaces = new Map<string, Workspace>()
     const groups = new Map<string, Set<string>>()
     for (const workspace of context.project.workspaces) {
-        if (
-            structUtils.areDescriptorsEqual(
-                context.project.topLevelWorkspace.anchoredDescriptor,
-                workspace.anchoredDescriptor,
-            ) ||
-            !workspace.manifest.name
-        )
-            continue
+        if (!workspace.manifest.name) continue
         const ident = structUtils.stringifyIdent(workspace.manifest.name)
         if (strategies.has(ident)) {
             workspaces.set(ident, workspace)

--- a/testUtils/setupMonorepo.ts
+++ b/testUtils/setupMonorepo.ts
@@ -15,36 +15,41 @@ async function writeJSON(filename: string, data: Record<string, unknown>): Promi
 }
 
 async function makeDependencyMap(
-    packages: Array<string | [string, string]>,
+    packages: Record<string, string> | Array<string | [string, string]>,
     { useRelativePath = true }: { useRelativePath?: boolean } = {},
 ): Promise<Record<string, string>> {
     const dependencies: Record<string, string> = {}
-    for (const pkg of packages) {
-        if (Array.isArray(pkg)) {
-            dependencies[pkg[0]] = pkg[1]
-        } else {
-            dependencies[pkg] = useRelativePath
-                ? `workspace:packages/${structUtils.parseIdent(pkg).name}`
-                : 'workspace:*'
+    if (Array.isArray(packages)) {
+        for (const pkg of packages) {
+            if (Array.isArray(pkg)) {
+                dependencies[pkg[0]] = pkg[1]
+            } else {
+                dependencies[pkg] = useRelativePath
+                    ? `workspace:packages/${structUtils.parseIdent(pkg).name}`
+                    : 'workspace:*'
+            }
         }
+    } else {
+        return { ...packages }
     }
     return dependencies
 }
 
 type PackageInitConfiguration = Partial<{
-    dependencies: Array<string | [string, string]>
-    devDependencies: Array<string | [string, string]>
-    peerDependencies: Array<string | [string, string]>
+    dependencies: Record<string, string> | Array<string | [string, string]>
+    devDependencies: Record<string, string> | Array<string | [string, string]>
+    peerDependencies: Record<string, string> | Array<string | [string, string]>
     scripts: Record<string, string>
     private: boolean
     version: string
     raw?: Record<string, any>
 }>
 
-type ProjectRootInitConfiguration = Partial<{
-    dependencies: Record<string, string | [string, string]>
-    repository: string
-}>
+type ProjectRootInitConfiguration = PackageInitConfiguration &
+    Partial<{
+        name?: string
+        repository: string
+    }>
 
 export default async function setupMonorepo(
     monorepo: Record<string, PackageInitConfiguration>,
@@ -60,11 +65,15 @@ export default async function setupMonorepo(
 
     // Generate root package.json
     await writeJSON(path.join(workingDir, 'package.json'), {
-        name: 'monorepo',
-        private: true,
-        version: '1.0.0',
-        workspaces: ['packages/*'],
-        dependencies: root?.dependencies ?? {},
+        name: root?.name ?? 'monorepo',
+        private: root?.private ?? true,
+        version: root?.version ?? '1.0.0',
+        workspaces: Object.keys(monorepo).length ? ['packages/*'] : undefined,
+        dependencies: await makeDependencyMap(root?.dependencies ?? []),
+        devDependencies: await makeDependencyMap(root?.devDependencies ?? []),
+        peerDependencies: await makeDependencyMap(root?.peerDependencies ?? [], {
+            useRelativePath: false,
+        }),
         repository: root?.repository,
     })
 


### PR DESCRIPTION
BREAKING CHANGE: Monodeploy will now publish the top level workspace if not marked as private, and if a change is detected. This means monodeploy can now be used to publish non-monorepos.

