### PR TITLE
fix: populate pre-release from the manifest in noRegistry mode

### DIFF
--- a/packages/versions/src/applyVersionStrategies.test.ts
+++ b/packages/versions/src/applyVersionStrategies.test.ts
@@ -394,4 +394,42 @@ describe('applyVersionStrategies prereleases', () => {
             expect(previous).toEqual(fromLatest)
         },
     )
+
+    describe('falls back to the latest version if no prerelease', () => {
+        it('increments using a prerelease if the base version is a prerelease (patch)', () => {
+            const { previous, next: actualVersion } = incrementVersion({
+                currentLatestVersion: '2.3.1-rc.2',
+                currentPrereleaseVersion: null,
+                strategy: 'patch',
+                prerelease: true,
+                prereleaseId: 'rc',
+            })
+            expect(actualVersion).toBe('2.3.1-rc.3')
+            expect(previous).toBe('2.3.1-rc.2')
+        })
+
+        it('increments using a prerelease if the base version is a prerelease (minor)', () => {
+            const { previous, next: actualVersion } = incrementVersion({
+                currentLatestVersion: '2.3.0-rc.2',
+                currentPrereleaseVersion: null,
+                strategy: 'patch',
+                prerelease: true,
+                prereleaseId: 'rc',
+            })
+            expect(actualVersion).toBe('2.3.0-rc.3')
+            expect(previous).toBe('2.3.0-rc.2')
+        })
+
+        it('increments using a prerelease if the base version is a prerelease (major)', () => {
+            const { previous, next: actualVersion } = incrementVersion({
+                currentLatestVersion: '2.0.0-rc.2',
+                currentPrereleaseVersion: null,
+                strategy: 'patch',
+                prerelease: true,
+                prereleaseId: 'rc',
+            })
+            expect(actualVersion).toBe('2.0.0-rc.3')
+            expect(previous).toBe('2.0.0-rc.2')
+        })
+    })
 })

--- a/packages/versions/src/applyVersionStrategies.ts
+++ b/packages/versions/src/applyVersionStrategies.ts
@@ -41,14 +41,11 @@ export const incrementVersion = ({
         }
     }
 
-    const semverInfo = currentPrereleaseVersion ? semver.parse(currentPrereleaseVersion) : null
+    const baseVersion =
+        maxVersion(currentPrereleaseVersion, currentLatestVersion) ?? currentLatestVersion
+    const semverInfo = semver.parse(baseVersion)
 
-    if (
-        !currentPrereleaseVersion ||
-        !semverInfo ||
-        // the prerelease version is outdated relative to latest
-        semverInfo.compare(currentLatestVersion) <= 0
-    ) {
+    if (!semverInfo?.prerelease?.length) {
         const releaseType: `pre${PackageStrategyType}` = `pre${strategy}`
         return {
             previous: currentLatestVersion,
@@ -62,8 +59,8 @@ export const incrementVersion = ({
         semverInfo.major > 0 && semverInfo.minor === 0 && semverInfo.patch === 0
     if (strategy === 'major' && !isPreleaseVersionMajor) {
         return {
-            previous: currentPrereleaseVersion,
-            next: semver.inc(currentPrereleaseVersion, 'premajor', prereleaseId),
+            previous: baseVersion,
+            next: semver.inc(baseVersion, 'premajor', prereleaseId),
             fromPrerelease: true,
         }
     }
@@ -71,15 +68,15 @@ export const incrementVersion = ({
     // if bumping to minor, but not already on major or patch
     if (strategy === 'minor' && semverInfo.patch !== 0) {
         return {
-            previous: currentPrereleaseVersion,
-            next: semver.inc(currentPrereleaseVersion, 'preminor', prereleaseId),
+            previous: baseVersion,
+            next: semver.inc(baseVersion, 'preminor', prereleaseId),
             fromPrerelease: true,
         }
     }
 
     return {
-        previous: currentPrereleaseVersion,
-        next: semver.inc(currentPrereleaseVersion, 'prerelease', prereleaseId),
+        previous: baseVersion,
+        next: semver.inc(baseVersion, 'prerelease', prereleaseId),
         fromPrerelease: true,
     }
 }


### PR DESCRIPTION
closes https://github.com/tophat/monodeploy/issues/478