### PR TITLE
refactor: disable pnp esm loader

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -45,3 +45,5 @@ plugins:
     spec: "https://raw.githubusercontent.com/tophat/yarn-plugin-semver-up/master/bundles/%40yarnpkg/plugin-semver-up.js"
 
 yarnPath: .yarn/releases/yarn-3.2.0.cjs
+
+pnpEnableEsmLoader: false


### PR DESCRIPTION
Can't enable ESM loader until https://github.com/nodejs/node/pull/42840 is merged. Otherwise the Node 14 test hangs.