### PR TITLE
fix: TypeError when registry returns version as array

### DIFF
--- a/packages/versions/src/getLatestPackageTags.ts
+++ b/packages/versions/src/getLatestPackageTags.ts
@@ -72,7 +72,13 @@ const getLatestPackageTags = async ({
                 }),
             )
 
-            return [pkgName, { latest: manifestVersion, ...result }]
+            // Result can contain versions as arrays, for example when using GitHub package registry
+            // `{ latest: ['1.0.0'] }` ==> `{ latest: '1.0.0' }`
+            const flatResult = Object.fromEntries(Object.entries(result).map(
+              ([key, value]) => [key, value.toString()]
+            ));
+            
+            return [pkgName, { latest: manifestVersion, ...flatResult }]
         } catch (err) {
             const statusCode = statusCodeFromHTTPError(err)
 


### PR DESCRIPTION
## Description

Fixes an issue where monodeploy fails with TypeError if the registry returns versions nested in an array.

This happens with GitHub package registry for example.

See the linked issue for more information.

## Related Issues

closes #498

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
N/A I have updated the relevant gatsby files (documentation).
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

