### PR TITLE
fix: TypeError when registry returns version as array

### DIFF
--- a/__mocks__/@yarnpkg/plugin-npm.ts
+++ b/__mocks__/@yarnpkg/plugin-npm.ts
@@ -3,7 +3,7 @@ import { Configuration, Ident, MessageName, ReportError, structUtils } from '@ya
 
 const actualModule = jest.requireActual('@yarnpkg/plugin-npm')
 
-const _registry: { tags: Record<string, Record<string, string>> } = {
+const _registry: { tags: Record<string, Record<string, string | string[]>> } = {
     tags: {},
 }
 
@@ -11,14 +11,14 @@ const _reset_ = (): void => {
     _registry.tags = {}
 }
 
-const _setTag_ = (pkgName: string, tagValue: string, tagKey = 'latest'): void => {
+const _setTag_ = (pkgName: string, tagValue: string | string[], tagKey = 'latest'): void => {
     _registry.tags[pkgName] = { ..._registry.tags[pkgName], [tagKey]: tagValue }
 }
 
 const npmHttpUtilsGet = (
     distTagUrl: string,
     { ident, registry }: { ident: Ident; registry: string },
-): Record<string, string> => {
+): Record<string, string | string[]> => {
     const pkgName = structUtils.stringifyIdent(ident)
     const tags = _registry.tags[pkgName]
     if (!tags) {

--- a/packages/versions/src/getLatestPackageTags.ts
+++ b/packages/versions/src/getLatestPackageTags.ts
@@ -11,6 +11,21 @@ interface NetworkError extends Error {
     readonly response?: Record<string, unknown> & { statusCode: number }
 }
 
+/**
+ * GitHub package registry may return versions in an array format, e.g.:
+ * `{ latest: ['1.0.0'] }` instead of `{ latest: '1.0.0' }`
+ */
+type RawDistTags = Partial<Record<string, string | [string]>>
+type NormalizedDistTags = Partial<Record<string, string>>
+
+function flattenDistTags(rawTags: RawDistTags): NormalizedDistTags {
+    const tags: NormalizedDistTags = {}
+    for (const [key, value] of Object.entries(rawTags)) {
+        tags[key] = Array.isArray(value) ? value[0] : value
+    }
+    return tags
+}
+
 function statusCodeFromHTTPError(err: unknown): number | undefined {
     if (isNodeError(err)) {
         if ('response' in err) {
@@ -63,7 +78,7 @@ const getLatestPackageTags = async ({
         const distTagUrl = `/-/package${identUrl}/dist-tags`
 
         try {
-            const result = await limitFetch(() =>
+            const result: RawDistTags = await limitFetch(() =>
                 pluginNPM.npmHttpUtils.get(distTagUrl, {
                     configuration: context.configuration,
                     ident,
@@ -72,13 +87,7 @@ const getLatestPackageTags = async ({
                 }),
             )
 
-            // Result can contain versions as arrays, for example when using GitHub package registry
-            // `{ latest: ['1.0.0'] }` ==> `{ latest: '1.0.0' }`
-            const flatResult = Object.fromEntries(Object.entries(result).map(
-              ([key, value]) => [key, value.toString()]
-            ));
-            
-            return [pkgName, { latest: manifestVersion, ...flatResult }]
+            return [pkgName, { latest: manifestVersion, ...flattenDistTags(result) }]
         } catch (err) {
             const statusCode = statusCodeFromHTTPError(err)
 

--- a/packages/versions/src/getLatestPackageTags.ts
+++ b/packages/versions/src/getLatestPackageTags.ts
@@ -72,7 +72,13 @@ const getLatestPackageTags = async ({
                 }),
             )
 
-            return [pkgName, { latest: manifestVersion, ...result }]
+            // Result can contain versions as arrays, for example when using GitHub package registry
+            // `{ latest: ['1.0.0'] }` ==> `{ latest: '1.0.0' }`
+            const flatResult = Object.fromEntries(Object.entries(result).map(
+              ([key, value]) => [key, value.toString()]
+            ));
+            
+            return [pkgName, { latest: manifestVersion, ...flatResult }]
         } catch (err) {
             const statusCode = statusCodeFromHTTPError(err)
 


### PR DESCRIPTION
https://github.com/tophat/monodeploy/pull/499

closes #498 