### PR TITLE
Fix links in getting started section

### DIFF
--- a/gatsby/src/pages/getting-started.mdx
+++ b/gatsby/src/pages/getting-started.mdx
@@ -25,7 +25,7 @@ Edit your project's root `package.json`:
 
   You'll be extending this file as you make changes to your project's publish configuration.
 
-3. If your packages require a compilation step (e.g. TypeScript, Babel), do this in a 'prepack' lifecycle hook per workspace. For more information about when prepack is called, [see Lifecycle Scripts](../architecture#lifecycle-scripts).
+3. If your packages require a compilation step (e.g. TypeScript, Babel), do this in a 'prepack' lifecycle hook per workspace. For more information about when prepack is called, [see Lifecycle Scripts](./architecture#lifecycle-scripts).
 
 For help with the CLI options:
 
@@ -33,7 +33,7 @@ For help with the CLI options:
 yarn monodeploy --help
 ```
 
-or see the [Configuration](../configuration) page for more details.
+or see the [Configuration](./configuration) page for more details.
 
 ### API
 


### PR DESCRIPTION
## Description

Fixes the links in the getting started section that lead to a 404

e.g. This PR refactors the X logic, applying Y's algorithm to improve Z by K percent.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #518 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
