### PR TITLE
feat: verify git credentials before deploying

### DIFF
--- a/__mocks__/@monodeploy/git.ts
+++ b/__mocks__/@monodeploy/git.ts
@@ -12,6 +12,7 @@ const registry: {
     lastTaggedCommit?: string
     pushedCommits: string[]
     stagedFiles: string[]
+    hasValidCredentials: boolean
 } = {
     commits: [],
     filesModified: new Map(),
@@ -20,6 +21,7 @@ const registry: {
     pushedCommits: [],
     lastTaggedCommit: undefined,
     stagedFiles: [],
+    hasValidCredentials: true,
 }
 
 const _reset_ = (): void => {
@@ -30,6 +32,7 @@ const _reset_ = (): void => {
     registry.pushedCommits = []
     registry.lastTaggedCommit = undefined
     registry.stagedFiles = []
+    registry.hasValidCredentials = true
 }
 
 const _commitFiles_ = (sha: string, commit: string, files: string[]): void => {
@@ -191,6 +194,18 @@ export const gitGlob = async (
     return globs // TODO: not entirely accurate
 }
 
+export const gitPushDryRun = async ({
+    cwd,
+    remote,
+    context,
+}: {
+    cwd: string
+    remote: string
+    context?: YarnContext
+}): Promise<boolean> => {
+    return registry.hasValidCredentials
+}
+
 module.exports = {
     __esModule: true,
     _commitFiles_,
@@ -211,4 +226,5 @@ module.exports = {
     gitPushTags,
     gitResolveSha,
     gitTag,
+    gitPushDryRun,
 }

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -172,3 +172,17 @@ export const gitCommit = async (
     assertProduction()
     await git(`commit -m "${message}" -n`, { cwd, context })
 }
+
+export const gitPushDryRun = async ({
+    cwd,
+    remote,
+    context,
+}: {
+    cwd: string
+    remote: string
+    context?: YarnContext
+}): Promise<boolean> => {
+    const result = await git(`push --dry-run ${remote}`, { cwd, context })
+
+    return result.code === 0
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -40,6 +40,7 @@ import { getGitTagsFromChangeset } from './utils/getGitTagsFromChangeset'
 import { mergeDefaultConfig } from './utils/mergeDefaultConfig'
 // import { readChangesetFile } from './utils/readChangesetFile'
 import { writeChangesetFile } from './utils/writeChangesetFile'
+import { verifyGitCredentials } from './verifyGitCredentials'
 
 const monodeploy = async (
     baseConfig: RecursivePartial<MonodeployConfiguration>,
@@ -131,6 +132,12 @@ const monodeploy = async (
             context,
             intentionalStrategies,
             implicitVersionStrategies,
+        })
+
+        // Verify if we can push to the remote repository
+        await verifyGitCredentials({
+            config,
+            context,
         })
 
         // Backup workspace package.jsons

--- a/packages/node/src/tests/main.test.ts
+++ b/packages/node/src/tests/main.test.ts
@@ -36,6 +36,7 @@ const mockGit = git as jest.Mocked<
             lastTaggedCommit?: string
             pushedCommits: string[]
             stagedFiles: string[]
+            hasValidCredentials: boolean
         }
     }
 >
@@ -682,5 +683,23 @@ describe('Monodeploy', () => {
             'pkg-3@7.0.0-alpha.1',
             'pkg-6@0.0.5-alpha.0',
         ])
+    })
+
+    it('checks if git credentials are valid', async () => {
+        mockNPM._setTag_('pkg-1', '0.0.1')
+        mockNPM._setTag_('pkg-2', '0.0.1')
+        mockNPM._setTag_('pkg-3', '0.0.1')
+        mockGit._commitFiles_('sha1', 'feat: some new feature!', ['./packages/pkg-1/README.md'])
+        mockGit._getRegistry_().hasValidCredentials = false
+
+        await expect(async () => {
+            await monodeploy({
+                ...monodeployConfig,
+                git: {
+                    ...monodeployConfig.git,
+                    push: true,
+                },
+            })
+        }).rejects.toThrow()
     })
 })

--- a/packages/node/src/verifyGitCredentials.ts
+++ b/packages/node/src/verifyGitCredentials.ts
@@ -1,0 +1,20 @@
+import { gitPushDryRun } from '@monodeploy/git'
+import { MonodeployConfiguration, YarnContext } from '@monodeploy/types'
+
+export async function verifyGitCredentials({
+    config,
+    context,
+}: {
+    config: MonodeployConfiguration
+    context: YarnContext
+}): Promise<void> {
+    if (!config.git.push) {
+        return
+    }
+
+    const canPush = await gitPushDryRun({ context, cwd: config.cwd, remote: config.git.remote })
+
+    if (!canPush) {
+        throw new Error('Cannot push to remote repository.')
+    }
+}


### PR DESCRIPTION
## Description

Verifies whether git credentials are valid and pushing is possible, throws an error if not before deploy steps are executed.

## Related Issues

- Closes #523, my own issue asking for this feature

## Checklist

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).
