### PR TITLE
feat: verify git commands before publishing packages

### DIFF
--- a/__mocks__/@monodeploy/git.ts
+++ b/__mocks__/@monodeploy/git.ts
@@ -82,11 +82,14 @@ const gitPushTags = async ({
     cwd,
     remote,
     context,
+    dryRun = false,
 }: {
     cwd: string
     remote: string
     context: YarnContext
+    dryRun?: boolean
 }): Promise<void> => {
+    if (dryRun) return
     registry.pushedTags = Array.from(new Set([...registry.pushedTags, ...registry.tags]))
 }
 
@@ -106,11 +109,14 @@ const gitPush = async ({
     cwd,
     remote,
     context,
+    dryRun = false,
 }: {
     cwd: string
     remote: string
     context: YarnContext
+    dryRun?: boolean
 }): Promise<void> => {
+    if (dryRun) return
     for (const commit of registry.commits) {
         registry.pushedCommits.push(commit.sha)
     }

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -10,7 +10,7 @@ const git = async (
     const command = `git ${subcommand}`
     logging.debug(`[Exec] ${command}`, { report: context?.report })
 
-    return await exec(command, { cwd })
+    return await exec(command, { cwd, env: { GIT_TERMINAL_PROMPT: '0', ...process.env } })
 }
 
 export const gitResolveSha = async (
@@ -61,13 +61,19 @@ export const gitPushTags = async ({
     cwd,
     remote,
     context,
+    dryRun = false,
 }: {
     cwd: string
     remote: string
     context?: YarnContext
+    dryRun?: boolean
 }): Promise<void> => {
     assertProduction()
-    await git(`push --tags ${remote}`, {
+
+    const args = ['--tags']
+    if (dryRun) args.push('--dry-run')
+
+    await git(`push ${args.join(' ')} ${remote}`, {
         cwd,
         context,
     })
@@ -93,13 +99,19 @@ export const gitPush = async ({
     cwd,
     remote,
     context,
+    dryRun = false,
 }: {
     cwd: string
     remote: string
     context?: YarnContext
+    dryRun?: boolean
 }): Promise<void> => {
     assertProduction()
-    await git(`push --no-verify ${remote}`, {
+
+    const args = ['--no-verify']
+    if (dryRun) args.push('--dry-run')
+
+    await git(`push ${args.join(' ')} ${remote}`, {
         cwd,
         context,
     })

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -325,11 +325,24 @@ const monodeploy = async (
             await report.startTimerPromise('Pushing Commit', { skipIfEmpty: true }, async () => {
                 if (!workspaces.size) return
 
+                if (config.dryRun) {
+                    // Ideally we use the git --dry-run commands in dry run, however this would be a
+                    // breaking change for projects that rely on dryRun to generate Pull Request change previews.
+                    // Once https://github.com/tophat/monodeploy/issues/493 is merged, we'll have a path forward for
+                    // the preview use case and can then remove the "if (!config.dryRun)" conditional as part of a
+                    // breaking change.
+                    if (config.git.push) {
+                        logging.info('[Publish] Pushing publish commit', {
+                            report: context?.report,
+                        })
+                    }
+                    return
+                }
+
                 await pushPublishCommit({
                     config,
                     context,
                     gitTags: restoredGitTags,
-                    dryRun: config.dryRun,
                 })
             })
 

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -65,18 +65,13 @@ export const pushPublishCommit = async ({
     config,
     context,
     gitTags,
+    dryRun = false,
 }: {
     config: MonodeployConfiguration
     context: YarnContext
     gitTags?: Map<string, string>
+    dryRun?: boolean
 }): Promise<void> => {
-    if (config.dryRun) {
-        logging.info('[Publish] Pushing publish commit', {
-            report: context?.report,
-        })
-        return
-    }
-
     if (!config.git.push) {
         return
     }
@@ -86,12 +81,14 @@ export const pushPublishCommit = async ({
             cwd: config.cwd,
             remote: config.git.remote,
             context,
+            dryRun,
         })
         if (config.git.tag && gitTags?.size) {
             await gitPushTags({
                 cwd: config.cwd,
                 remote: config.git.remote,
                 context,
+                dryRun,
             })
         }
     } else {
@@ -102,6 +99,7 @@ export const pushPublishCommit = async ({
                 cwd: config.cwd,
                 remote: config.git.remote,
                 context,
+                dryRun,
             })
         }
     }

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -65,7 +65,7 @@ export const pushPublishCommit = async ({
     config,
     context,
     gitTags,
-    dryRun = false,
+    dryRun = config.dryRun,
 }: {
     config: MonodeployConfiguration
     context: YarnContext


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Alternative to https://github.com/tophat/monodeploy/pull/524, addressing https://github.com/tophat/monodeploy/issues/523.

This only addresses "verify git credentials" in non-dry run mode which is better than the current state of things.