### PR TITLE
fix: allow auto-committing without persisting versions

### DIFF
--- a/packages/node/src/tests/main.test.ts
+++ b/packages/node/src/tests/main.test.ts
@@ -580,6 +580,7 @@ describe('Monodeploy', () => {
                 mockGit._getRegistry_().commits[mockGit._getRegistry_().commits.length - 1]
             const autoCommitFiles = mockGit._getRegistry_().filesModified.get(autoCommit.sha)
             expect(autoCommitFiles).toEqual(expect.arrayContaining([changelogFilename]))
+            expect(autoCommitFiles).not.toEqual(expect.arrayContaining(['**/package.json']))
 
             // assert commit pushed
             expect(mockGit._getRegistry_().pushedCommits).toEqual(

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -31,16 +31,16 @@ export const createPublishCommit = async ({
     if (config.autoCommit) {
         const globs = []
 
-        if (config?.persistVersions) {
+        if (config.persistVersions) {
             // Push package.json and related changes
-            globs.push(...['yarn.lock', 'package.json', '**/package.json', '.pnp.*'])
+            globs.push('yarn.lock', 'package.json', '**/package.json', '.pnp.*')
         }
-        if (config?.changelogFilename) {
+        if (config.changelogFilename) {
             // Push changelog changes
             globs.push(config.changelogFilename.replace('<packageDir>', '**'))
         }
 
-        const files = await gitGlob(globs, { cwd: config.cwd, context })
+        const files = globs.length ? await gitGlob(globs, { cwd: config.cwd, context }) : []
         if (files.length) {
             await gitAdd(files, { cwd: config.cwd, context })
             await gitCommit(config.autoCommitMessage, { cwd: config.cwd, context })

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -29,11 +29,17 @@ export const createPublishCommit = async ({
     }
 
     if (config.autoCommit) {
-        // Push artifacts (changelog, package.json changes)
-        const globs = ['yarn.lock', 'package.json', '**/package.json', '.pnp.*']
+        const globs = []
+
+        if (config?.persistVersions) {
+            // Push package.json and related changes
+            globs.push(...['yarn.lock', 'package.json', '**/package.json', '.pnp.*'])
+        }
         if (config?.changelogFilename) {
+            // Push changelog changes
             globs.push(config.changelogFilename.replace('<packageDir>', '**'))
         }
+
         const files = await gitGlob(globs, { cwd: config.cwd, context })
         if (files.length) {
             await gitAdd(files, { cwd: config.cwd, context })

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -29,7 +29,7 @@ export const createPublishCommit = async ({
     }
 
     if (config.autoCommit) {
-        const globs = []
+        const globs: string[] = []
 
         if (config.persistVersions) {
             // Push package.json and related changes

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -134,7 +134,8 @@ export interface MonodeployConfiguration {
 
     /**
      * The filename to write changelogs to, assuming a conventional changelog config has been set.
-     * Use '<packageDir>' to reference the cwd of an individual workspace.
+     * Use '<packageDir>' to reference the cwd of an individual workspace. You should also enable
+     * 'autoCommit' when this is set so that the changelogs are committed to your repo.
      */
     changelogFilename?: string
 
@@ -168,14 +169,17 @@ export interface MonodeployConfiguration {
      * Whether to persist package.json modifications, i.e. updating the dependency versions
      * and the version field of each published workspace. Most publishing tools act as if this
      * is enabled. It can be useful to disable version persistence if you do not want your CI
-     * environment to write back to your Git repository. Useful for runners like Jenkins.
+     * environment to write back to your Git repository. Useful for runners like Jenkins. You
+     * should also enable 'autoCommit' when this is set so that the changelogs are committed
+     * to your repo.
      *
      * @default false
      */
     persistVersions: boolean
 
     /**
-     * Whether to automatically create a release commit, for use with persistVersions.
+     * Whether to automatically create a release commit after a publish. If using autoCommit,
+     * you must also have one of 'persistVersions' or 'changelogFilename' set.
      *
      * @default false
      */


### PR DESCRIPTION
## Description

If autocommit is enabled, monodeploy **always** follows the logic of `persistVersions` even if `persistVersions` is set to false. This change allows you commit changelogs without `persistVersions` being true.

## Related Issues

- Closes #592, which introduced this problem
- Closes #591, which is the documentation for these features

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
