### PR TITLE
fix: Clean up modified files after autocommit

### DIFF
--- a/__mocks__/@monodeploy/git.ts
+++ b/__mocks__/@monodeploy/git.ts
@@ -138,6 +138,26 @@ export const gitCommit = async (
     registry.stagedFiles = []
 }
 
+export const gitResetHard = async ({
+    cwd,
+    context,
+}: {
+    cwd: string
+    context?: YarnContext
+}): Promise<void> => {
+    registry.stagedFiles = []
+}
+
+export const gitClean = async ({
+    cwd,
+    context,
+}: {
+    cwd: string
+    context?: YarnContext
+}): Promise<void> => {
+    registry.stagedFiles = []
+}
+
 const gitLastTaggedCommit = async ({
     cwd,
     context,
@@ -207,6 +227,7 @@ module.exports = {
     ...actualMonodeployGit,
     getCommitMessages,
     gitAdd,
+    gitClean,
     gitCommit,
     gitDiffTree,
     gitLastTaggedCommit,
@@ -215,6 +236,7 @@ module.exports = {
     gitGlob,
     gitPush,
     gitPushTags,
+    gitResetHard,
     gitResolveSha,
     gitTag,
 }

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -184,3 +184,23 @@ export const gitCommit = async (
     assertProduction()
     await git(`commit -m "${message}" -n`, { cwd, context })
 }
+
+export const gitResetHard = async ({
+    cwd,
+    context,
+}: {
+    cwd: string
+    context?: YarnContext
+}): Promise<void> => {
+    await git('reset --hard', { cwd, context })
+}
+
+export const gitClean = async ({
+    cwd,
+    context,
+}: {
+    cwd: string
+    context?: YarnContext
+}): Promise<void> => {
+    await git('clean -fd', { cwd, context })
+}

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -42,21 +42,14 @@ export const createPublishCommit = async ({
             globs.push(config.changelogFilename.replace('<packageDir>', '**'))
         }
 
-        console.log('1')
         const files = globs.length ? await gitGlob(globs, { cwd: config.cwd, context }) : []
-        console.log('2')
         if (files.length) {
-            console.log('3')
             await gitAdd(files, { cwd: config.cwd, context })
-            console.log('4')
             await gitCommit(config.autoCommitMessage, { cwd: config.cwd, context })
-            console.log('5')
 
             // clean up any files that were modified but not committed
             await gitResetHard({ cwd: config.cwd, context })
-            console.log('6')
             await gitClean({ cwd: config.cwd, context })
-            console.log('7')
         }
     }
 

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -1,10 +1,12 @@
 import {
     gitAdd,
+    gitClean,
     gitCommit,
     gitGlob,
     gitPull,
     gitPush,
     gitPushTags,
+    gitResetHard,
     gitResolveSha,
 } from '@monodeploy/git'
 import logging from '@monodeploy/logging'
@@ -40,10 +42,21 @@ export const createPublishCommit = async ({
             globs.push(config.changelogFilename.replace('<packageDir>', '**'))
         }
 
+        console.log('1')
         const files = globs.length ? await gitGlob(globs, { cwd: config.cwd, context }) : []
+        console.log('2')
         if (files.length) {
+            console.log('3')
             await gitAdd(files, { cwd: config.cwd, context })
+            console.log('4')
             await gitCommit(config.autoCommitMessage, { cwd: config.cwd, context })
+            console.log('5')
+
+            // clean up any files that were modified but not committed
+            await gitResetHard({ cwd: config.cwd, context })
+            console.log('6')
+            await gitClean({ cwd: config.cwd, context })
+            console.log('7')
         }
     }
 


### PR DESCRIPTION
## Description

With the recent change to allow for committing of changelogs but not persisting versions (https://github.com/tophat/monodeploy/pull/593) we introduced an error. Now, if you only commit changelogs, then there are modified files on your branch, which prevents the rebase from succeeding.

We need to clean modified files after we do the autocommit to ensure the rebase will work.

## Related Issues

https://github.com/tophat/monodeploy/issues/592

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
