### PR TITLE
fix: Stash changes before pull

### DIFF
--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -83,13 +83,17 @@ export const gitPull = async ({
     cwd,
     remote,
     context,
+    autostash = false,
 }: {
     cwd: string
     remote: string
     context?: YarnContext
+    autostash?: boolean
 }): Promise<void> => {
     assertProduction()
-    await git(`pull --rebase --no-verify ${remote}`, {
+    const args = ['--rebase', '--no-verify']
+    if (autostash) args.push('--autostash')
+    await git(`pull ${args.join(' ')} ${remote}`, {
         cwd,
         context,
     })

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -61,6 +61,7 @@ export const createPublishCommit = async ({
             cwd: config.cwd,
             remote: config.git.remote,
             context,
+            autostash: true,
         })
     }
 


### PR DESCRIPTION
## Description

When we introduced this change https://github.com/tophat/monodeploy/pull/593 it ended up introducing a new failure case.

> 11:10:31  ➤ YN0001: │ Error: Executing 'git pull --rebase --no-verify origin' failed with code: 128
> 11:10:31  
> 11:10:31  error: cannot pull with rebase: You have unstaged changes.
> 11:10:31  error: please commit or stash them.

If you are committing changelogs but not persisting changes, then you cannot do a git pull with rebase, since the modified `package.json` files locally are still on the working branch. We need those files later on when publishing, so we cannot just clean/reset ([as was the strategy here](https://github.com/tophat/monodeploy/pull/594)). This adds an `--autostash` argument to the pull which will resolve the problem.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
