### PR TITLE
fix: ensures changelog files are up to date before adding entries

### DIFF
--- a/__mocks__/@monodeploy/git.ts
+++ b/__mocks__/@monodeploy/git.ts
@@ -197,6 +197,13 @@ export const gitGlob = async (
     return globs // TODO: not entirely accurate
 }
 
+export const gitCheckout = async (
+    { files }: { files: string[] },
+    { cwd, context }: { cwd: string; context?: YarnContext },
+): Promise<void> => {
+    //
+}
+
 module.exports = {
     __esModule: true,
     _commitFiles_,

--- a/packages/changelog/src/prependChangelogFile.ts
+++ b/packages/changelog/src/prependChangelogFile.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 
+import { gitCheckout } from '@monodeploy/git'
 import logging from '@monodeploy/logging'
 import {
     type ChangesetSchema,
@@ -75,13 +76,27 @@ const prependChangelogFile = async ({
     context,
     changeset,
     workspaces,
+    forceRefreshChangelogs = false,
 }: {
     config: MonodeployConfiguration
     context: YarnContext
     changeset: ChangesetSchema
     workspaces: Set<Workspace>
+    forceRefreshChangelogs?: boolean
 }): Promise<void> => {
     if (!config.changelogFilename) return
+
+    // Make sure the changelogs are up to date with the remote
+    if (!config.dryRun && forceRefreshChangelogs) {
+        const changelogGlob = config.changelogFilename.replace('<packageDir>', '**')
+        if (changelogGlob) {
+            try {
+                await gitCheckout({ files: [changelogGlob] }, { cwd: config.cwd, context })
+            } catch {
+                logging.debug('Force refreshing changelogs failed.', { report: context.report })
+            }
+        }
+    }
 
     if (config.changelogFilename.includes(TOKEN_PACKAGE_DIR)) {
         const prependForWorkspace = async (workspace: Workspace): Promise<void> => {

--- a/packages/changelog/src/prependChangelogFile.ts
+++ b/packages/changelog/src/prependChangelogFile.ts
@@ -93,7 +93,9 @@ const prependChangelogFile = async ({
             try {
                 await gitCheckout({ files: [changelogGlob] }, { cwd: config.cwd, context })
             } catch {
-                logging.debug('Force refreshing changelogs failed.', { report: context.report })
+                logging.debug('Force refreshing changelogs failed. Ignoring.', {
+                    report: context.report,
+                })
             }
         }
     }

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -17,11 +17,14 @@ export const gitCheckout = async (
     { files }: { files: string[] },
     { cwd, context }: { cwd: string; context?: YarnContext },
 ): Promise<void> => {
-    const { stdout: branch } = await git('rev-parse --abbrev-ref --symbolic-full-name @{u}', {
+    const { stdout: branch } = await git('rev-parse --abbrev-ref --symbolic-full-name @\\{u\\}', {
         cwd,
         context,
     })
-    await git(`checkout ${branch.trim()} -- ${files.join(' ')}`, { cwd, context })
+    await git(`checkout ${branch.trim()} -- ${files.map((f) => `"${f}"`).join(' ')}`, {
+        cwd,
+        context,
+    })
 }
 
 export const gitResolveSha = async (

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -13,6 +13,17 @@ const git = async (
     return await exec(command, { cwd, env: { GIT_TERMINAL_PROMPT: '0', ...process.env } })
 }
 
+export const gitCheckout = async (
+    { files }: { files: string[] },
+    { cwd, context }: { cwd: string; context?: YarnContext },
+): Promise<void> => {
+    const { stdout: branch } = await git('rev-parse --abbrev-ref --symbolic-full-name @{u}', {
+        cwd,
+        context,
+    })
+    await git(`checkout ${branch.trim()} -- ${files.join(' ')}`, { cwd, context })
+}
+
 export const gitResolveSha = async (
     ref: string,
     { cwd, context }: { cwd: string; context?: YarnContext },
@@ -84,15 +95,18 @@ export const gitPull = async ({
     remote,
     context,
     autostash = false,
+    strategyOption,
 }: {
     cwd: string
     remote: string
     context?: YarnContext
     autostash?: boolean
+    strategyOption?: 'theirs'
 }): Promise<void> => {
     assertProduction()
     const args = ['--rebase', '--no-verify']
     if (autostash) args.push('--autostash')
+    if (strategyOption) args.push(`--strategy-option=${strategyOption}`)
     await git(`pull ${args.join(' ')} ${remote}`, {
         cwd,
         context,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -214,15 +214,6 @@ const monodeploy = async (
             resolve()
         })
 
-        await report.startTimerPromise('Updating Changelog', { skipIfEmpty: false }, async () => {
-            await prependChangelogFile({
-                config,
-                context,
-                changeset,
-                workspaces,
-            })
-        })
-
         try {
             // Update package.jsons (the main destructive action which requires the backup)
             await report.startTimerPromise(
@@ -269,6 +260,20 @@ const monodeploy = async (
 
             let publishCommitSha: string | undefined
             const restoredGitTags = getGitTagsFromChangeset(changeset)
+
+            await report.startTimerPromise(
+                'Updating Changelog',
+                { skipIfEmpty: false },
+                async () => {
+                    await prependChangelogFile({
+                        config,
+                        context,
+                        changeset,
+                        workspaces,
+                        forceRefreshChangelogs: config.autoCommit && config.git.push,
+                    })
+                },
+            )
 
             await report.startTimerPromise(
                 'Committing Changes',

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -47,15 +47,6 @@ export const createPublishCommit = async ({
         }
     }
 
-    if (config.git.tag && gitTags?.size) {
-        // Tag commit
-        await createReleaseGitTags({
-            config,
-            context,
-            gitTags,
-        })
-    }
-
     if (config.git.push && config.autoCommit) {
         await gitPull({
             cwd: config.cwd,
@@ -63,6 +54,15 @@ export const createPublishCommit = async ({
             context,
             autostash: true,
             strategyOption: 'theirs',
+        })
+    }
+
+    if (config.git.tag && gitTags?.size) {
+        // Tag commit
+        await createReleaseGitTags({
+            config,
+            context,
+            gitTags,
         })
     }
 

--- a/packages/publish/src/commitPublishChanges.ts
+++ b/packages/publish/src/commitPublishChanges.ts
@@ -62,6 +62,7 @@ export const createPublishCommit = async ({
             remote: config.git.remote,
             context,
             autostash: true,
+            strategyOption: 'theirs',
         })
     }
 


### PR DESCRIPTION
## Description

Addresses the changelog portion of #601. We move the changelog updates closer to the commit stage, and ensure we "refresh" the changelogs prior to prepending entries. This reduces the possibility of conflicts, assuming the pipeline running monodeploy takes appropriate measures to "lock" the publish stage (to limit concurrency). If a conflict is detected, we attempt a merge, preferring our changes over the remote.
