### PR TITLE
docs: clarify plugin options usage

### DIFF
--- a/gatsby/src/pages/plugins.mdx
+++ b/gatsby/src/pages/plugins.mdx
@@ -17,12 +17,17 @@ plugins: ['@monodeploy/plugin-github']
 yarn monodeploy --plugins @monodeploy/plugin-github
 ```
 
-A plugin is a module which exposes a function as the default. This function takes PluginHooks as the first argument and plugin options as the second.
+A plugin is a module which exports a function as the default. This function takes PluginHooks as the first argument and plugin options as the second.
 
-Plugin options can only be passed through a config file, and are not supported through the command line:
+Plugin options can only be passed through a config file, and are not supported through the command line.
+
+> Note: when passing options to a plugin, the plugin entry must be an array with the plugin name first and the options second
 
 ```raw
-plugins: ['@monodeploy/plugin-github', { someArbitraryOption: 'value' }]
+plugins: [
+  '@monodeploy/plugin-without-options',
+  ['@monodeploy/plugin-with-options', { someArbitraryOption: 'value' }]
+]
 ```
 
 You can then "tap" into the hooks.
@@ -38,7 +43,9 @@ The GitHub plugin creates GitHub releases. It requires a `GH_TOKEN` environment 
 By default, implicit version updates do not get a dedicated release. To change this behaviour, set `includeImplicitUpdates` to `true`:
 
 ```raw
-plugins: ['@monodeploy/plugin-github', { includeImplicitUpdates: true }]
+plugins: [
+  ['@monodeploy/plugin-github', { includeImplicitUpdates: true }]
+]
 ```
 
 ## Plugin Development
@@ -50,3 +57,5 @@ We use [tapable](https://github.com/webpack/tapable) for an experimental plugin 
 #### onReleaseAvailable
 
 This hook is triggered once a release is available, after publishing to npm, and after pushing any artifacts such as git tags to the repository (assuming running with autoCommit and push mode).
+
+


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

The Plugins page has incorrect information on passing options to plugins. This PR fixes that.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

While I was developing a plugin with custom options, I noticed that monodeploy would throw when I specified the options the way it is described in the docs. So I updated the docs to reflect the actual behavior.

