### PR TITLE
fix: parse repository subgroup correctly

### DIFF
--- a/packages/git/src/parseRepositoryProperty.test.ts
+++ b/packages/git/src/parseRepositoryProperty.test.ts
@@ -4,7 +4,7 @@ import { structUtils } from '@yarnpkg/core'
 import { parseRepositoryProperty } from './parseRepositoryProperty'
 
 describe('parseRepositoryProperty', () => {
-    it('parses repository from manifest url as string', async () =>
+    it('parses github repository from manifest url as string', async () =>
         withMonorepoContext({ 'pkg-1': {} }, async (context) => {
             const workspace = context.project.getWorkspaceByIdent(structUtils.parseIdent('pkg-1'))
 
@@ -38,6 +38,50 @@ describe('parseRepositoryProperty', () => {
                     owner: 'tophat',
                     repository: 'monodeploy',
                     repoUrl: 'git+https://github.com/tophat/monodeploy',
+                }),
+            )
+        }))
+
+    it('parses arbitrary repository from manifest url as string', async () =>
+        withMonorepoContext({ 'pkg-1': {} }, async (context) => {
+            const workspace = context.project.getWorkspaceByIdent(structUtils.parseIdent('pkg-1'))
+
+            workspace.manifest.setRawField(
+                'repository',
+                'git@anyhost.net:group/subgroup/sub-subgroup/package-name.git',
+            )
+            expect(await parseRepositoryProperty(workspace)).toEqual(
+                expect.objectContaining({
+                    host: 'https://anyhost.net',
+                    owner: 'group/subgroup/sub-subgroup',
+                    repository: 'package-name',
+                    repoUrl: 'https://anyhost.net/group/subgroup/sub-subgroup/package-name',
+                }),
+            )
+
+            workspace.manifest.setRawField(
+                'repository',
+                'https://anyhost.net/group/subgroup/sub-subgroup/package-name.git',
+            )
+            expect(await parseRepositoryProperty(workspace)).toEqual(
+                expect.objectContaining({
+                    host: 'https://anyhost.net',
+                    owner: 'group/subgroup/sub-subgroup',
+                    repository: 'package-name',
+                    repoUrl: 'https://anyhost.net/group/subgroup/sub-subgroup/package-name',
+                }),
+            )
+
+            workspace.manifest.setRawField(
+                'repository',
+                'git+https://anyhost.net/group/subgroup/sub-subgroup/package-name.git',
+            )
+            expect(await parseRepositoryProperty(workspace)).toEqual(
+                expect.objectContaining({
+                    host: 'https://anyhost.net',
+                    owner: 'group/subgroup/sub-subgroup',
+                    repository: 'package-name',
+                    repoUrl: 'git+https://anyhost.net/group/subgroup/sub-subgroup/package-name',
                 }),
             )
         }))

--- a/packages/git/src/parseRepositoryProperty.ts
+++ b/packages/git/src/parseRepositoryProperty.ts
@@ -9,11 +9,11 @@ export type RepositoryInfo = {
 
 const REPOSITORY_PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => Partial<RepositoryInfo>]> = [
     [
-        /((?:git\+)?(https?:\/\/[^/]+)\/([^/]+)\/([^/.]+))(?:\.git)?/,
+        /((?:git\+)?(https?:\/\/[^/]+)\/([^.]+)\/([^/.]+))(?:\.git)?/,
         (m) => ({ repoUrl: m[1], host: m[2], owner: m[3], repository: m[4] }),
     ],
     [
-        /(?:git@)?([^:]+):([^/]+)\/([^/.]+)(?:\.git)?/,
+        /(?:git@)?([^:]+):([^.]+)\/([^/.]+)(?:\.git)?/,
         (m) => ({
             repoUrl: `https://${m[1]}/${m[2]}/${m[3]}`,
             host: `https://${m[1]}`,


### PR DESCRIPTION
## Description

Fixes the `parseRepositoryProperty` function to correctly parse repository urls if there are multiple subgroups in it.

## Related Issues

Relates to #782 

## Checklist

- [x] I agree to abide by the [Code of Conduct](https://github.com/tophat/monodeploy/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
