### PR TITLE
fix: remove deprecated registry CLI flag

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -31,7 +31,7 @@ describe('CLI', () => {
     describe('CLI Args', () => {
         it('passes cli flags to monodeploy', async () => {
             setArgs(
-                '--registry-url http://example.com --no-registry --cwd /tmp --dry-run ' +
+                '--registry-url http://example.com --cwd /tmp --dry-run ' +
                     '--git-base-branch main --git-commit-sha HEAD --git-remote origin ' +
                     '--log-level 0 --conventional-changelog-config @my/config ' +
                     '--changeset-filename changes.json --changelog-filename changelog.md --force-write-change-files ' +

--- a/packages/cli/src/command/base.ts
+++ b/packages/cli/src/command/base.ts
@@ -30,11 +30,6 @@ export abstract class BaseCommand extends Command {
         description: 'The URL of the registry to publish to',
     })
 
-    registry = Option.Boolean('--registry', true, {
-        description:
-            'Whether to read and write to the npm-like registry (deprecated, use --registry-mode instead)',
-    })
-
     registryMode = Option.String('--registry-mode', {
         description: 'The type of "registry" to use as the source of truth for package versions.',
         validator: t.isEnum(RegistryMode),


### PR DESCRIPTION
BREAKING CHANGE: Remove deprecated '--no-registry' CLI flag. Use '--registry-mode=manifest' instead.
