### PR TITLE
chore: add deprecation notice, note to switch to monoweave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# ⚠️ DEPRECATION NOTICE
+
+> Monodeploy has been replaced by [Monoweave](https://github.com/monoweave/monoweave). Monoweave supports all the functionality of monodeploy, with additional features, bug fixes, and continued development.
+
 # monodeploy
 
 <span><img align="right" width="200" height="200" src="./assets/monodeploy.svg" alt="monodeploy"></span>


### PR DESCRIPTION
Monodeploy was forked to monoweave a few months ago, and monoweave has already drifted from monodeploy with additional features and bug fixes.